### PR TITLE
Add topology roomstamp feasibility worker

### DIFF
--- a/api-gateway/api-gateway.py
+++ b/api-gateway/api-gateway.py
@@ -38,6 +38,7 @@ from shared.classes import (
     IfcPatchListRecipesResponse,
     RevitExecuteRequest,
     IfcCoordRequest,
+    IfcTopologyRequest,
 )  
 from pydantic import BaseModel, HttpUrl
 from redis import Redis
@@ -77,6 +78,7 @@ ifc5d_queue = Queue('ifc5d', connection=redis_conn)
 ifcpatch_queue = Queue('ifcpatch', connection=redis_conn)
 revit_queue = Queue('revit', connection=redis_conn)
 ifccoord_queue = Queue('ifccoord', connection=redis_conn)
+ifctopology_queue = Queue('ifctopology', connection=redis_conn)
 
 # Define job status response model
 class JobStatusResponse(BaseModel):
@@ -278,6 +280,7 @@ async def health_check():
         "ifcpatch_queue": "waiting",
         "revit_queue": "waiting",
         "ifccoord_queue": "waiting",
+        "ifctopology_queue": "waiting",
         "default_queue": "waiting",
     }
 
@@ -307,6 +310,7 @@ async def health_check():
         "ifcpatch_queue": ifcpatch_queue,
         "revit_queue": revit_queue,
         "ifccoord_queue": ifccoord_queue,
+        "ifctopology_queue": ifctopology_queue,
         "default_queue": default_queue
     }
     
@@ -588,6 +592,30 @@ async def ifccoord(request: IfcCoordRequest, _: str = Depends(verify_access)):
         return {"job_id": job.id}
     except Exception as e:
         logger.error(f"Error enqueueing ifccoord job: {str(e)}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/ifctopology/roomstamp", tags=["Topology"])
+async def ifctopology_roomstamp(request: IfcTopologyRequest, _: str = Depends(verify_access)):
+    """
+    Benchmark room/zone containment across one or more spatial IFC files and
+    one or more target element IFC files. When `stamp=true`, matched room and
+    zone data is written into a property set on the target element models.
+    """
+    try:
+        for filename in request.spatial_files + request.element_files:
+            validate_input_file_exists(filename)
+
+        job = ifctopology_queue.enqueue(
+            "tasks.run_roomstamp_benchmark",
+            request.dict(),
+            job_timeout="4h",
+            result_ttl=JOB_RESULT_TTL,
+        )
+
+        logger.info(f"Enqueued ifctopology roomstamp job with ID: {job.id}")
+        return {"job_id": job.id}
+    except Exception as e:
+        logger.error(f"Error enqueueing ifctopology roomstamp job: {str(e)}")
         raise HTTPException(status_code=500, detail=str(e))
 
 @app.post("/ifctester", tags=["Validation"])

--- a/api-gateway/api-gateway.py
+++ b/api-gateway/api-gateway.py
@@ -225,8 +225,27 @@ def validate_input_file_exists(filename: str, base_dir: str = "/uploads") -> Non
     `output/patch/…`, never under `uploads/`. Previously those were rejected
     as 404 even though the worker would have downloaded them fine.
     """
-    path = os.path.join(base_dir, os.path.basename(filename))
-    if os.path.exists(path):
+    normalized = filename.lstrip("/")
+    filesystem_candidates = []
+    if normalized.startswith("uploads/"):
+        filesystem_candidates.append(("/uploads", normalized[len("uploads/"):]))
+    elif normalized.startswith("output/"):
+        filesystem_candidates.append(("/output", normalized[len("output/"):]))
+    elif normalized.startswith("examples/"):
+        filesystem_candidates.append(("/examples", normalized[len("examples/"):]))
+    else:
+        filesystem_candidates.append((base_dir, normalized))
+
+    for root, relative in filesystem_candidates:
+        candidate_path = os.path.normpath(os.path.join(root, relative))
+        root_abs = os.path.abspath(root)
+        if os.path.commonpath([root_abs, os.path.abspath(candidate_path)]) == root_abs and os.path.exists(candidate_path):
+            return
+
+    # Legacy callers sometimes submit just a basename even if upstream nodes
+    # provide a longer path. Keep that fallback for older n8n workflows.
+    legacy_path = os.path.join(base_dir, os.path.basename(filename))
+    if os.path.exists(legacy_path):
         return
     if s3.is_enabled():
         # 1) Legacy basename lookup under uploads/
@@ -597,9 +616,10 @@ async def ifccoord(request: IfcCoordRequest, _: str = Depends(verify_access)):
 @app.post("/ifctopology/roomstamp", tags=["Topology"])
 async def ifctopology_roomstamp(request: IfcTopologyRequest, _: str = Depends(verify_access)):
     """
-    Benchmark room/zone containment across one or more spatial IFC files and
+    Federate room/zone containment across one or more spatial IFC files and
     one or more target element IFC files. When `stamp=true`, matched room and
-    zone data is written into a property set on the target element models.
+    zone data is written into a property set on stamped copies of the target
+    element models.
     """
     try:
         for filename in request.spatial_files + request.element_files:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
         condition: service_started
       ifcpatch-worker:
         condition: service_started
+      ifctopology-worker:
+        condition: service_started
       ifccoord-worker:
         condition: service_started
       redis:
@@ -269,6 +271,46 @@ services:
         limits:
           cpus: '1.0'
           memory: 2G
+
+  ifctopology-worker:
+    build:
+      context: .
+      dockerfile: ifctopology-worker/Dockerfile
+    platform: linux/amd64
+    user: "1000:1000"
+    volumes:
+      - ./shared/uploads:/uploads
+      - ./shared/output:/output
+      - ./shared/examples:/examples
+    environment:
+      - PYTHONUNBUFFERED=1
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - REDIS_URL=redis://redis:6379/0
+      - POSTGRES_HOST=postgres
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=${POSTGRES_DB:-ifcpipeline}
+      - POSTGRES_USER=${POSTGRES_USER:-ifcpipeline}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set in .env}
+      - USE_OBJECT_STORAGE=${USE_OBJECT_STORAGE:-true}
+      - S3_ENDPOINT_URL=${S3_ENDPOINT_URL:-http://minio:9000}
+      - S3_ACCESS_KEY=${S3_ACCESS_KEY:-minioadmin}
+      - S3_SECRET_KEY=${S3_SECRET_KEY:-minioadmin}
+      - S3_BUCKET=${S3_BUCKET:-ifcpipeline}
+      - S3_REGION=${S3_REGION:-us-east-1}
+    depends_on:
+      redis:
+        condition: service_started
+      postgres:
+        condition: service_healthy
+      minio-setup:
+        condition: service_started
+    restart: unless-stopped
+    deploy:
+      replicas: 1
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
 
   ifcconvert-worker:
     build:

--- a/ifctopology-worker/Dockerfile
+++ b/ifctopology-worker/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:3.11-slim AS base
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python -m pip install --upgrade pip
+
+COPY shared /app/shared
+RUN pip install -e /app/shared
+
+COPY ifctopology-worker/requirements.txt /app/
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY ifctopology-worker/tasks.py /app/
+
+RUN mkdir -p /output/topology /uploads
+RUN chmod -R 777 /output /uploads
+
+ENV PYTHONPATH=/app
+ENV PYTHONUNBUFFERED=1
+
+CMD ["rq", "worker", "ifctopology", "--url", "redis://redis:6379/0", "--path", "/app"]

--- a/ifctopology-worker/README.md
+++ b/ifctopology-worker/README.md
@@ -1,9 +1,9 @@
-# IFC Topology Worker Feasibility
+# IFC Topology Worker
 
-`ifctopology-worker` is an experimental RQ worker for evaluating room/zone
-stamping across federated IFC models. The first benchmark targets the common
-workflow of stamping thousands of MEP elements from one or more target models
-against rooms and zones from one or more spatial/architecture models.
+`ifctopology-worker` is a dedicated RQ worker for federating spatial
+relationships into IFC element properties. It targets the common workflow of
+stamping thousands of MEP elements from one or more target models against rooms
+and zones from one or more spatial/architecture models.
 
 ## Endpoint
 
@@ -24,13 +24,25 @@ Example request:
   "engine": "auto",
   "sample_strategy": "bbox_centroid",
   "stamp": false,
+  "stamp_ambiguous": false,
   "tolerance": 0.01
 }
 ```
 
-Set `stamp=true` only after reviewing a dry-run report. Stamping writes
-`Pset_IfcPipelineRoomStamp` to matched target elements with:
+Run with `stamp=false` first to review the match report. Set `stamp=true` to
+write a new stamped IFC for each target model. By default, ambiguous matches
+are skipped and reported; set `stamp_ambiguous=true` only if your workflow
+accepts choosing the smallest matching space.
 
+Stamping writes `Pset_IfcPipelineRoomStamp` to matched target elements with:
+
+- `SpatialMatchStatus`
+- `SpatialMatchCount`
+- `SpatialSourceFile`
+- `SpatialRelationshipEngine`
+- `SpaceGlobalId`
+- `SpaceName`
+- `SpaceLongName`
 - `RoomGlobalId`
 - `RoomName`
 - `RoomLongName`
@@ -50,6 +62,7 @@ The report JSON includes:
 - optional IFC stamping/write time
 - candidate test count
 - matched, unmatched, and ambiguous match counts
+- stamped, skipped ambiguous, and skipped unmatched counts
 - TopologicPy import availability/version/import overhead
 
 The `bbox` engine uses IfcOpenShell world-coordinate geometry bounding boxes.
@@ -59,9 +72,21 @@ sample point. This is intentionally simple and repeatable: it establishes the
 minimum viable throughput and highlights model quality issues before investing
 in exact TopologicPy cells generated from room solids or richer spatial topology.
 
+## Workflow usage
+
+Supported input references match normal IfcPipeline chaining:
+
+- `model.ifc` or `uploads/model.ifc`
+- `output/patch/model_patched.ifc`
+- `examples/Building-Architecture.ifc`
+- S3 object keys when object storage is enabled
+
+Outputs are always rooted under `output/topology/` in S3 mode or
+`/output/topology/` in filesystem mode.
+
 ## TopologicPy decision criteria
 
-Use this worker to answer:
+Use this worker to answer and then tune:
 
 1. Can TopologicPy be installed reliably in the worker image alongside
    IfcOpenShell?
@@ -95,3 +120,20 @@ curl -X POST http://localhost:8100/ifctopology/roomstamp \
 
 Review `shared/output/topology/topology_roomstamp_report.json` or the returned
 S3 output key before enabling `stamp=true`.
+
+Then stamp reviewed matches into a new IFC:
+
+```bash
+curl -X POST http://localhost:8100/ifctopology/roomstamp \
+  -H "X-API-Key: ${IFC_PIPELINE_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "spatial_files": ["Building-Architecture.ifc"],
+    "element_files": ["Building-Hvac.ifc"],
+    "output_file": "topology_roomstamp_stamp_report.json",
+    "output_ifc_prefix": "stamped",
+    "engine": "auto",
+    "stamp": true,
+    "stamp_ambiguous": false
+  }'
+```

--- a/ifctopology-worker/README.md
+++ b/ifctopology-worker/README.md
@@ -1,0 +1,97 @@
+# IFC Topology Worker Feasibility
+
+`ifctopology-worker` is an experimental RQ worker for evaluating room/zone
+stamping across federated IFC models. The first benchmark targets the common
+workflow of stamping thousands of MEP elements from one or more target models
+against rooms and zones from one or more spatial/architecture models.
+
+## Endpoint
+
+```http
+POST /ifctopology/roomstamp
+```
+
+Example request:
+
+```json
+{
+  "spatial_files": ["Building-Architecture.ifc"],
+  "element_files": ["Building-Hvac.ifc"],
+  "output_file": "topology_roomstamp_report.json",
+  "element_query": "IfcDistributionElement",
+  "space_query": "IfcSpace",
+  "include_zones": true,
+  "engine": "auto",
+  "sample_strategy": "bbox_centroid",
+  "stamp": false,
+  "tolerance": 0.01
+}
+```
+
+Set `stamp=true` only after reviewing a dry-run report. Stamping writes
+`Pset_IfcPipelineRoomStamp` to matched target elements with:
+
+- `RoomGlobalId`
+- `RoomName`
+- `RoomLongName`
+- `BuildingStoreyName`
+- `ZoneNames`
+- `ZoneGlobalIds`
+- `StampedBy`
+
+## What it benchmarks
+
+The report JSON includes:
+
+- model load time
+- room/space geometry indexing time
+- target element geometry time
+- containment match time
+- optional IFC stamping/write time
+- candidate test count
+- matched, unmatched, and ambiguous match counts
+- TopologicPy import availability/version/import overhead
+
+The `bbox` engine uses IfcOpenShell world-coordinate geometry bounding boxes.
+The `topologicpy` engine converts those room bounding boxes into TopologicPy
+prism cells and runs TopologicPy point containment against each target element
+sample point. This is intentionally simple and repeatable: it establishes the
+minimum viable throughput and highlights model quality issues before investing
+in exact TopologicPy cells generated from room solids or richer spatial topology.
+
+## TopologicPy decision criteria
+
+Use this worker to answer:
+
+1. Can TopologicPy be installed reliably in the worker image alongside
+   IfcOpenShell?
+2. Does import/runtime overhead remain acceptable for queued jobs?
+3. How many room candidates and MEP element samples are involved per federated
+   workflow?
+4. How often do bounding-box matches become ambiguous or miss expected rooms?
+5. Which models need precise room cell topology instead of fast bbox indexing?
+
+If bbox-derived cells show high ambiguous or false-positive rates, the next
+step is to generate TopologicPy cells from IfcSpace solids while keeping the
+same request/response contract.
+
+## Local smoke request
+
+After starting Docker Compose and uploading/copying the sample files to
+`shared/uploads`, enqueue a dry run through the API:
+
+```bash
+curl -X POST http://localhost:8100/ifctopology/roomstamp \
+  -H "X-API-Key: ${IFC_PIPELINE_API_KEY}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "spatial_files": ["Building-Architecture.ifc"],
+    "element_files": ["Building-Hvac.ifc"],
+    "output_file": "topology_roomstamp_report.json",
+    "engine": "auto",
+    "stamp": false
+  }'
+```
+
+Review `shared/output/topology/topology_roomstamp_report.json` or the returned
+S3 output key before enabling `stamp=true`.

--- a/ifctopology-worker/requirements.txt
+++ b/ifctopology-worker/requirements.txt
@@ -1,0 +1,14 @@
+# IFC dependencies - keep aligned with newer worker images
+ifcopenshell==0.8.4
+
+# Topology feasibility dependency. Lower bounds match the latest versions
+# verified during this worker spike.
+topologicpy>=0.9.43
+tqdm>=4.68.1
+
+# Queue and data validation
+rq>=2.0.0,<3.0.0
+pydantic>=2.9.0,<3.0.0
+
+# Object storage
+boto3>=1.34,<2

--- a/ifctopology-worker/tasks.py
+++ b/ifctopology-worker/tasks.py
@@ -23,6 +23,9 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 WORKER_NAME = "ifctopology-worker"
+UPLOADS_DIR = os.environ.get("IFCPIPELINE_UPLOADS_DIR", "/uploads")
+OUTPUT_DIR = os.environ.get("IFCPIPELINE_OUTPUT_DIR", "/output")
+EXAMPLES_DIR = os.environ.get("IFCPIPELINE_EXAMPLES_DIR", "/examples")
 
 
 Point = Tuple[float, float, float]
@@ -352,6 +355,8 @@ def _element_payload(element: ElementCandidate, matches: List[SpaceCandidate]) -
         "sample_point": list(element.sample_point),
         "bbox": element.bbox.to_dict() if element.bbox else None,
         "matched_space": _space_payload(chosen),
+        "matched_spaces": [_space_payload(space) for space in matches],
+        "match_status": "ambiguous" if len(matches) > 1 else "matched" if matches else "unmatched",
         "match_count": len(matches),
     }
 
@@ -369,12 +374,26 @@ def _get_or_create_pset(model: Any, element: Any, pset_name: str) -> Any:
     return ifcopenshell.api.run("pset.add_pset", model, product=element, name=pset_name)
 
 
-def _stamp_element(model: Any, element: Any, space: SpaceCandidate, pset_name: str) -> None:
+def _stamp_element(
+    model: Any,
+    element: Any,
+    space: SpaceCandidate,
+    matches: List[SpaceCandidate],
+    pset_name: str,
+    selected_engine: str,
+) -> None:
     import ifcopenshell.api
 
     zone_names = [zone.get("name") for zone in space.zones if zone.get("name")]
     zone_ids = [zone.get("global_id") for zone in space.zones if zone.get("global_id")]
     properties = {
+        "SpatialMatchStatus": "Ambiguous" if len(matches) > 1 else "Matched",
+        "SpatialMatchCount": str(len(matches)),
+        "SpatialSourceFile": space.source_file,
+        "SpatialRelationshipEngine": selected_engine,
+        "SpaceGlobalId": space.global_id,
+        "SpaceName": space.name or "",
+        "SpaceLongName": space.long_name or "",
         "RoomGlobalId": space.global_id,
         "RoomName": space.name or "",
         "RoomLongName": space.long_name or "",
@@ -401,11 +420,28 @@ def _stage_inputs(files: List[str], tmpdir: str) -> Tuple[Dict[str, str], List[s
             normalized = filename.lstrip("/")
             if normalized.startswith("uploads/"):
                 normalized = normalized[len("uploads/"):]
-            local_path = os.path.join("/uploads", normalized)
+                local_path = os.path.join(UPLOADS_DIR, normalized)
+            elif normalized.startswith("output/"):
+                local_path = os.path.join(OUTPUT_DIR, normalized[len("output/"):])
+            elif normalized.startswith("examples/"):
+                local_path = os.path.join(EXAMPLES_DIR, normalized[len("examples/"):])
+            else:
+                local_path = os.path.join(UPLOADS_DIR, normalized)
             if not os.path.exists(local_path):
                 raise FileNotFoundError(f"Input IFC file not found: {filename}")
         paths[filename] = local_path
     return paths, keys
+
+
+def _path_under_output_root(output_dir: str, requested_path: str) -> str:
+    normalized = requested_path.strip("/")
+    if normalized.startswith("output/topology/"):
+        normalized = normalized[len("output/topology/"):]
+    elif normalized.startswith("output/"):
+        normalized = os.path.basename(normalized)
+    if not normalized:
+        normalized = "topology_roomstamp_report.json"
+    return os.path.join(output_dir, normalized)
 
 
 def _default_stamped_name(source_name: str, index: int) -> str:
@@ -418,6 +454,10 @@ def _output_ifc_path(request: IfcTopologyRequest, output_dir: str, source_name: 
         return os.path.join(output_dir, _default_stamped_name(source_name, index))
 
     prefix = request.output_ifc_prefix.strip("/")
+    if prefix.startswith("output/topology/"):
+        prefix = prefix[len("output/topology/"):]
+    elif prefix.startswith("output/"):
+        prefix = os.path.basename(prefix)
     if not prefix:
         return os.path.join(output_dir, _default_stamped_name(source_name, index))
     if prefix.lower().endswith(".ifc") and len(request.element_files) == 1:
@@ -442,9 +482,9 @@ def run_roomstamp_benchmark(job_data: dict) -> dict:
     try:
         all_inputs = list(dict.fromkeys(request.spatial_files + request.element_files))
         local_paths, input_keys = _stage_inputs(all_inputs, tmpdir)
-        output_dir = os.path.join(tmpdir, "output") if s3.is_enabled() else "/output/topology"
+        output_dir = os.path.join(tmpdir, "output") if s3.is_enabled() else os.path.join(OUTPUT_DIR, "topology")
         os.makedirs(output_dir, exist_ok=True)
-        report_path = os.path.join(output_dir, os.path.basename(request.output_file))
+        report_path = _path_under_output_root(output_dir, request.output_file)
         settings = _geometry_settings()
 
         load_start = time.perf_counter()
@@ -525,15 +565,35 @@ def run_roomstamp_benchmark(job_data: dict) -> dict:
         match_seconds = time.perf_counter() - match_start
 
         stamped_outputs: List[Dict[str, Any]] = []
+        stamped_count = 0
+        skipped_ambiguous_count = 0
+        skipped_unmatched_count = 0
         if request.stamp:
             stamp_start = time.perf_counter()
             for index, filename in enumerate(request.element_files, start=1):
                 model = element_models[filename]
                 stamped = 0
+                skipped_ambiguous = 0
+                skipped_unmatched = 0
                 for element, matches in matches_by_file[filename]:
-                    if matches:
-                        _stamp_element(model, element.element, matches[0], request.pset_name)
-                        stamped += 1
+                    if not matches:
+                        skipped_unmatched += 1
+                        continue
+                    if len(matches) > 1 and not request.stamp_ambiguous:
+                        skipped_ambiguous += 1
+                        continue
+                    _stamp_element(
+                        model,
+                        element.element,
+                        matches[0],
+                        matches,
+                        request.pset_name,
+                        selected_engine,
+                    )
+                    stamped += 1
+                    stamped_count += 1
+                skipped_ambiguous_count += skipped_ambiguous
+                skipped_unmatched_count += skipped_unmatched
 
                 out_path = _output_ifc_path(request, output_dir, filename, index)
                 os.makedirs(os.path.dirname(out_path), exist_ok=True)
@@ -541,6 +601,8 @@ def run_roomstamp_benchmark(job_data: dict) -> dict:
                 stamped_outputs.append({
                     "source_file": filename,
                     "stamped_element_count": stamped,
+                    "skipped_ambiguous_count": skipped_ambiguous,
+                    "skipped_unmatched_count": skipped_unmatched,
                     "output_path": out_path,
                 })
             stamp_seconds = time.perf_counter() - stamp_start
@@ -569,6 +631,10 @@ def run_roomstamp_benchmark(job_data: dict) -> dict:
             "candidate_tests": candidate_tests,
             "matches_per_second": round(total_elements / match_seconds, 2) if match_seconds else total_elements,
             "stamp": request.stamp,
+            "stamp_ambiguous": request.stamp_ambiguous,
+            "stamped_count": stamped_count,
+            "skipped_ambiguous_count": skipped_ambiguous_count,
+            "skipped_unmatched_count": skipped_unmatched_count,
             "space_geometry_failures": space_geometry_failures,
             "element_geometry_failures": element_geometry_failures,
         }
@@ -628,8 +694,9 @@ def run_roomstamp_benchmark(job_data: dict) -> dict:
 
             uploaded_ifcs = []
             for item in stamped_outputs:
+                relative_output = os.path.relpath(item["output_path"], output_dir)
                 key = s3.normalize_output_key(
-                    os.path.basename(item["output_path"]),
+                    relative_output,
                     "topology",
                 )
                 audit_ifc = s3.upload_and_audit(
@@ -641,6 +708,8 @@ def run_roomstamp_benchmark(job_data: dict) -> dict:
                     parents=[("input", s3.normalize_input_key(item["source_file"]))],
                     metadata={
                         "stamped_element_count": item["stamped_element_count"],
+                        "skipped_ambiguous_count": item["skipped_ambiguous_count"],
+                        "skipped_unmatched_count": item["skipped_unmatched_count"],
                         "pset_name": request.pset_name,
                     },
                     content_type="application/x-step",

--- a/ifctopology-worker/tasks.py
+++ b/ifctopology-worker/tasks.py
@@ -1,0 +1,663 @@
+import json
+import logging
+import os
+import shutil
+import tempfile
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import ifcopenshell
+import ifcopenshell.geom
+import ifcopenshell.util.selector
+from shared import object_storage as s3
+from shared.classes import IfcTopologyRequest, TopologyEngine, TopologySampleStrategy
+
+try:
+    import ifcopenshell.util.placement
+except Exception:  # pragma: no cover - depends on IfcOpenShell wheel contents
+    ifcopenshell.util.placement = None
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+WORKER_NAME = "ifctopology-worker"
+
+
+Point = Tuple[float, float, float]
+
+
+@dataclass
+class BBox:
+    min_x: float
+    min_y: float
+    min_z: float
+    max_x: float
+    max_y: float
+    max_z: float
+
+    @property
+    def centroid(self) -> Point:
+        return (
+            (self.min_x + self.max_x) / 2.0,
+            (self.min_y + self.max_y) / 2.0,
+            (self.min_z + self.max_z) / 2.0,
+        )
+
+    @property
+    def volume(self) -> float:
+        return (
+            max(0.0, self.max_x - self.min_x)
+            * max(0.0, self.max_y - self.min_y)
+            * max(0.0, self.max_z - self.min_z)
+        )
+
+    def contains_point(self, point: Point, tolerance: float) -> bool:
+        x, y, z = point
+        return (
+            self.min_x - tolerance <= x <= self.max_x + tolerance
+            and self.min_y - tolerance <= y <= self.max_y + tolerance
+            and self.min_z - tolerance <= z <= self.max_z + tolerance
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "min": [self.min_x, self.min_y, self.min_z],
+            "max": [self.max_x, self.max_y, self.max_z],
+            "centroid": list(self.centroid),
+            "volume": self.volume,
+        }
+
+
+@dataclass
+class SpaceCandidate:
+    source_file: str
+    global_id: str
+    name: Optional[str]
+    long_name: Optional[str]
+    storey: Optional[str]
+    zones: List[Dict[str, Optional[str]]]
+    bbox: BBox
+    topology_cell: Any = None
+
+
+@dataclass
+class ElementCandidate:
+    source_file: str
+    element: Any
+    global_id: str
+    ifc_class: str
+    name: Optional[str]
+    sample_point: Point
+    bbox: Optional[BBox]
+
+
+def _current_job_id() -> Optional[str]:
+    try:
+        from rq import get_current_job
+
+        job = get_current_job()
+        return job.id if job else None
+    except Exception:
+        return None
+
+
+def _topologicpy_status() -> Dict[str, Any]:
+    start = time.perf_counter()
+    try:
+        import topologicpy  # type: ignore
+
+        return {
+            "available": True,
+            "version": getattr(topologicpy, "__version__", "unknown"),
+            "import_seconds": round(time.perf_counter() - start, 6),
+        }
+    except Exception as exc:
+        return {
+            "available": False,
+            "error": str(exc),
+            "import_seconds": round(time.perf_counter() - start, 6),
+        }
+
+
+def _selected_engine(request: IfcTopologyRequest, status: Dict[str, Any]) -> str:
+    if request.engine == TopologyEngine.BBOX:
+        return TopologyEngine.BBOX.value
+    if request.engine == TopologyEngine.TOPOLOGICPY:
+        if not status["available"]:
+            raise RuntimeError(f"TopologicPy engine requested but unavailable: {status.get('error')}")
+        # First pass keeps the containment implementation comparable with the
+        # bbox baseline while measuring TopologicPy import/runtime overhead.
+        return TopologyEngine.TOPOLOGICPY.value
+    return TopologyEngine.TOPOLOGICPY.value if status["available"] else TopologyEngine.BBOX.value
+
+
+def _geometry_settings():
+    settings = ifcopenshell.geom.settings()
+    try:
+        settings.set(settings.USE_WORLD_COORDS, True)
+    except Exception:
+        try:
+            settings.set("USE_WORLD_COORDS", True)
+        except Exception:
+            logger.warning("IfcOpenShell wheel does not support USE_WORLD_COORDS setting")
+    return settings
+
+
+def _bbox_from_shape(model: Any, product: Any, settings: Any) -> Optional[BBox]:
+    try:
+        shape = ifcopenshell.geom.create_shape(settings, product)
+        verts = list(shape.geometry.verts)
+    except Exception as exc:
+        logger.debug("Could not create shape for %s: %s", getattr(product, "GlobalId", None), exc)
+        return None
+
+    if len(verts) < 3:
+        return None
+
+    xs = verts[0::3]
+    ys = verts[1::3]
+    zs = verts[2::3]
+    return BBox(min(xs), min(ys), min(zs), max(xs), max(ys), max(zs))
+
+
+def _placement_point(product: Any) -> Optional[Point]:
+    placement_module = getattr(ifcopenshell.util, "placement", None)
+    if placement_module is None or not getattr(product, "ObjectPlacement", None):
+        return None
+    try:
+        matrix = placement_module.get_local_placement(product.ObjectPlacement)
+        return (float(matrix[0][3]), float(matrix[1][3]), float(matrix[2][3]))
+    except Exception:
+        return None
+
+
+def _sample_point(
+    product: Any,
+    bbox: Optional[BBox],
+    sample_strategy: TopologySampleStrategy,
+) -> Optional[Point]:
+    if sample_strategy == TopologySampleStrategy.PLACEMENT:
+        return _placement_point(product) or (bbox.centroid if bbox else None)
+    return bbox.centroid if bbox else _placement_point(product)
+
+
+def _filter_elements(model: Any, query: str) -> List[Any]:
+    try:
+        return list(ifcopenshell.util.selector.filter_elements(model, query))
+    except Exception:
+        logger.debug("Selector query failed; falling back to by_type(%s)", query, exc_info=True)
+        return list(model.by_type(query))
+
+
+def _space_storey(space: Any) -> Optional[str]:
+    for rel in getattr(space, "ContainedInStructure", []) or []:
+        structure = getattr(rel, "RelatingStructure", None)
+        if structure:
+            return getattr(structure, "Name", None)
+    return None
+
+
+def _zone_assignments(model: Any) -> Dict[str, List[Dict[str, Optional[str]]]]:
+    assignments: Dict[str, List[Dict[str, Optional[str]]]] = {}
+    for rel in model.by_type("IfcRelAssignsToGroup"):
+        group = getattr(rel, "RelatingGroup", None)
+        if not group or not group.is_a("IfcZone"):
+            continue
+        zone = {
+            "global_id": getattr(group, "GlobalId", None),
+            "name": getattr(group, "Name", None),
+            "long_name": getattr(group, "LongName", None),
+        }
+        for obj in getattr(rel, "RelatedObjects", []) or []:
+            guid = getattr(obj, "GlobalId", None)
+            if guid:
+                assignments.setdefault(guid, []).append(zone)
+    return assignments
+
+
+def _collect_spaces(
+    model: Any,
+    source_file: str,
+    query: str,
+    include_zones: bool,
+    settings: Any,
+) -> Tuple[List[SpaceCandidate], int]:
+    zones = _zone_assignments(model) if include_zones else {}
+    spaces: List[SpaceCandidate] = []
+    geometry_failures = 0
+
+    for space in _filter_elements(model, query):
+        bbox = _bbox_from_shape(model, space, settings)
+        if bbox is None:
+            geometry_failures += 1
+            continue
+        spaces.append(
+            SpaceCandidate(
+                source_file=source_file,
+                global_id=getattr(space, "GlobalId", ""),
+                name=getattr(space, "Name", None),
+                long_name=getattr(space, "LongName", None),
+                storey=_space_storey(space),
+                zones=zones.get(getattr(space, "GlobalId", ""), []),
+                bbox=bbox,
+            )
+        )
+
+    spaces.sort(key=lambda item: item.bbox.volume)
+    return spaces, geometry_failures
+
+
+def _collect_elements(
+    model: Any,
+    source_file: str,
+    query: str,
+    settings: Any,
+    sample_strategy: TopologySampleStrategy,
+    max_elements: Optional[int],
+) -> Tuple[List[ElementCandidate], int]:
+    elements: List[ElementCandidate] = []
+    geometry_failures = 0
+
+    for product in _filter_elements(model, query):
+        if max_elements is not None and len(elements) >= max_elements:
+            break
+        bbox = _bbox_from_shape(model, product, settings)
+        point = _sample_point(product, bbox, sample_strategy)
+        if point is None:
+            geometry_failures += 1
+            continue
+        elements.append(
+            ElementCandidate(
+                source_file=source_file,
+                element=product,
+                global_id=getattr(product, "GlobalId", ""),
+                ifc_class=product.is_a(),
+                name=getattr(product, "Name", None),
+                sample_point=point,
+                bbox=bbox,
+            )
+        )
+
+    return elements, geometry_failures
+
+
+def _build_topologic_bbox_cells(spaces: Iterable[SpaceCandidate], tolerance: float) -> int:
+    from topologicpy.Cell import Cell
+    from topologicpy.Vertex import Vertex
+
+    built = 0
+    for space in spaces:
+        bbox = space.bbox
+        width = max(tolerance, bbox.max_x - bbox.min_x)
+        length = max(tolerance, bbox.max_y - bbox.min_y)
+        height = max(tolerance, bbox.max_z - bbox.min_z)
+        origin = Vertex.ByCoordinates(*bbox.centroid)
+        space.topology_cell = Cell.Prism(
+            origin=origin,
+            width=width,
+            length=length,
+            height=height,
+            placement="center",
+            tolerance=max(tolerance, 0.0001),
+        )
+        built += 1
+    return built
+
+
+def _topologic_contains(space: SpaceCandidate, point: Point, tolerance: float) -> bool:
+    from topologicpy.Cell import Cell
+    from topologicpy.Vertex import Vertex
+
+    if space.topology_cell is None:
+        return space.bbox.contains_point(point, tolerance)
+    vertex = Vertex.ByCoordinates(*point)
+    status = Cell.ContainmentStatus(space.topology_cell, vertex, tolerance=max(tolerance, 0.0001))
+    return status in (0, 1)
+
+
+def _match_element_to_spaces(
+    element: ElementCandidate,
+    spaces: Iterable[SpaceCandidate],
+    tolerance: float,
+    selected_engine: str,
+) -> List[SpaceCandidate]:
+    if selected_engine == TopologyEngine.TOPOLOGICPY.value:
+        return [space for space in spaces if _topologic_contains(space, element.sample_point, tolerance)]
+    return [space for space in spaces if space.bbox.contains_point(element.sample_point, tolerance)]
+
+
+def _space_payload(space: Optional[SpaceCandidate]) -> Optional[Dict[str, Any]]:
+    if space is None:
+        return None
+    return {
+        "source_file": space.source_file,
+        "global_id": space.global_id,
+        "name": space.name,
+        "long_name": space.long_name,
+        "storey": space.storey,
+        "zones": space.zones,
+        "bbox": space.bbox.to_dict(),
+    }
+
+
+def _element_payload(element: ElementCandidate, matches: List[SpaceCandidate]) -> Dict[str, Any]:
+    chosen = matches[0] if matches else None
+    return {
+        "source_file": element.source_file,
+        "global_id": element.global_id,
+        "ifc_class": element.ifc_class,
+        "name": element.name,
+        "sample_point": list(element.sample_point),
+        "bbox": element.bbox.to_dict() if element.bbox else None,
+        "matched_space": _space_payload(chosen),
+        "match_count": len(matches),
+    }
+
+
+def _get_or_create_pset(model: Any, element: Any, pset_name: str) -> Any:
+    for rel in getattr(element, "IsDefinedBy", []) or []:
+        if not rel.is_a("IfcRelDefinesByProperties"):
+            continue
+        pset = getattr(rel, "RelatingPropertyDefinition", None)
+        if pset and pset.is_a("IfcPropertySet") and getattr(pset, "Name", None) == pset_name:
+            return pset
+
+    import ifcopenshell.api
+
+    return ifcopenshell.api.run("pset.add_pset", model, product=element, name=pset_name)
+
+
+def _stamp_element(model: Any, element: Any, space: SpaceCandidate, pset_name: str) -> None:
+    import ifcopenshell.api
+
+    zone_names = [zone.get("name") for zone in space.zones if zone.get("name")]
+    zone_ids = [zone.get("global_id") for zone in space.zones if zone.get("global_id")]
+    properties = {
+        "RoomGlobalId": space.global_id,
+        "RoomName": space.name or "",
+        "RoomLongName": space.long_name or "",
+        "BuildingStoreyName": space.storey or "",
+        "ZoneNames": ", ".join(zone_names),
+        "ZoneGlobalIds": ", ".join(zone_ids),
+        "StampedBy": "ifctopology-worker",
+    }
+    pset = _get_or_create_pset(model, element, pset_name)
+    ifcopenshell.api.run("pset.edit_pset", model, pset=pset, properties=properties)
+
+
+def _stage_inputs(files: List[str], tmpdir: str) -> Tuple[Dict[str, str], List[str]]:
+    paths: Dict[str, str] = {}
+    keys: List[str] = []
+    for index, filename in enumerate(files):
+        if s3.is_enabled():
+            key = s3.normalize_input_key(filename)
+            keys.append(key)
+            local_name = os.path.basename(key) or "input.ifc"
+            local_path = os.path.join(tmpdir, f"{index}-{local_name}")
+            s3.get_client().download_file(Bucket=s3.bucket_name(), Key=key, Filename=local_path)
+        else:
+            normalized = filename.lstrip("/")
+            if normalized.startswith("uploads/"):
+                normalized = normalized[len("uploads/"):]
+            local_path = os.path.join("/uploads", normalized)
+            if not os.path.exists(local_path):
+                raise FileNotFoundError(f"Input IFC file not found: {filename}")
+        paths[filename] = local_path
+    return paths, keys
+
+
+def _default_stamped_name(source_name: str, index: int) -> str:
+    base, ext = os.path.splitext(os.path.basename(source_name))
+    return f"{base or 'model'}_roomstamped_{index}{ext or '.ifc'}"
+
+
+def _output_ifc_path(request: IfcTopologyRequest, output_dir: str, source_name: str, index: int) -> str:
+    if not request.output_ifc_prefix:
+        return os.path.join(output_dir, _default_stamped_name(source_name, index))
+
+    prefix = request.output_ifc_prefix.strip("/")
+    if not prefix:
+        return os.path.join(output_dir, _default_stamped_name(source_name, index))
+    if prefix.lower().endswith(".ifc") and len(request.element_files) == 1:
+        return os.path.join(output_dir, os.path.basename(prefix))
+    return os.path.join(output_dir, prefix, _default_stamped_name(source_name, index))
+
+
+def _write_json(path: str, payload: Dict[str, Any]) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2)
+
+
+def run_roomstamp_benchmark(job_data: dict) -> dict:
+    """Benchmark room/zone containment and optionally stamp target IFC models."""
+    request = IfcTopologyRequest(**job_data)
+    start = time.perf_counter()
+    topologicpy = _topologicpy_status()
+    selected_engine = _selected_engine(request, topologicpy)
+    tmpdir = tempfile.mkdtemp(prefix="ifctopology-")
+
+    try:
+        all_inputs = list(dict.fromkeys(request.spatial_files + request.element_files))
+        local_paths, input_keys = _stage_inputs(all_inputs, tmpdir)
+        output_dir = os.path.join(tmpdir, "output") if s3.is_enabled() else "/output/topology"
+        os.makedirs(output_dir, exist_ok=True)
+        report_path = os.path.join(output_dir, os.path.basename(request.output_file))
+        settings = _geometry_settings()
+
+        load_start = time.perf_counter()
+        spatial_models = {
+            filename: ifcopenshell.open(local_paths[filename])
+            for filename in request.spatial_files
+        }
+        element_models = {
+            filename: ifcopenshell.open(local_paths[filename])
+            for filename in request.element_files
+        }
+        load_seconds = time.perf_counter() - load_start
+
+        space_start = time.perf_counter()
+        spaces: List[SpaceCandidate] = []
+        space_geometry_failures = 0
+        for filename, model in spatial_models.items():
+            collected, failures = _collect_spaces(
+                model,
+                filename,
+                request.space_query,
+                request.include_zones,
+                settings,
+            )
+            spaces.extend(collected)
+            space_geometry_failures += failures
+        spaces.sort(key=lambda item: item.bbox.volume)
+        space_seconds = time.perf_counter() - space_start
+
+        topologic_cell_count = 0
+        topologic_cell_seconds = 0.0
+        if selected_engine == TopologyEngine.TOPOLOGICPY.value:
+            topologic_cell_start = time.perf_counter()
+            topologic_cell_count = _build_topologic_bbox_cells(spaces, request.tolerance)
+            topologic_cell_seconds = time.perf_counter() - topologic_cell_start
+
+        element_start = time.perf_counter()
+        elements_by_file: Dict[str, List[ElementCandidate]] = {}
+        element_geometry_failures = 0
+        for filename, model in element_models.items():
+            collected, failures = _collect_elements(
+                model,
+                filename,
+                request.element_query,
+                settings,
+                request.sample_strategy,
+                request.max_elements,
+            )
+            elements_by_file[filename] = collected
+            element_geometry_failures += failures
+        element_seconds = time.perf_counter() - element_start
+
+        match_start = time.perf_counter()
+        matches_by_file: Dict[str, List[Tuple[ElementCandidate, List[SpaceCandidate]]]] = {}
+        element_results: List[Dict[str, Any]] = []
+        matched_count = 0
+        ambiguous_count = 0
+        total_elements = 0
+        candidate_tests = 0
+
+        for filename, elements in elements_by_file.items():
+            matches_by_file[filename] = []
+            for element in elements:
+                matches = _match_element_to_spaces(
+                    element,
+                    spaces,
+                    request.tolerance,
+                    selected_engine,
+                )
+                candidate_tests += len(spaces)
+                total_elements += 1
+                if matches:
+                    matched_count += 1
+                if len(matches) > 1:
+                    ambiguous_count += 1
+                matches_by_file[filename].append((element, matches))
+                element_results.append(_element_payload(element, matches))
+        match_seconds = time.perf_counter() - match_start
+
+        stamped_outputs: List[Dict[str, Any]] = []
+        if request.stamp:
+            stamp_start = time.perf_counter()
+            for index, filename in enumerate(request.element_files, start=1):
+                model = element_models[filename]
+                stamped = 0
+                for element, matches in matches_by_file[filename]:
+                    if matches:
+                        _stamp_element(model, element.element, matches[0], request.pset_name)
+                        stamped += 1
+
+                out_path = _output_ifc_path(request, output_dir, filename, index)
+                os.makedirs(os.path.dirname(out_path), exist_ok=True)
+                model.write(out_path)
+                stamped_outputs.append({
+                    "source_file": filename,
+                    "stamped_element_count": stamped,
+                    "output_path": out_path,
+                })
+            stamp_seconds = time.perf_counter() - stamp_start
+        else:
+            stamp_seconds = 0.0
+
+        elapsed_seconds = time.perf_counter() - start
+        summary = {
+            "engine_requested": request.engine.value,
+            "engine_selected": selected_engine,
+            "containment_method": (
+                "topologicpy_bbox_cell"
+                if selected_engine == TopologyEngine.TOPOLOGICPY.value
+                else "bbox"
+            ),
+            "topologicpy_used_for_containment": selected_engine == TopologyEngine.TOPOLOGICPY.value,
+            "topologic_cell_count": topologic_cell_count,
+            "sample_strategy": request.sample_strategy.value,
+            "spatial_file_count": len(request.spatial_files),
+            "element_file_count": len(request.element_files),
+            "space_count": len(spaces),
+            "element_count": total_elements,
+            "matched_count": matched_count,
+            "unmatched_count": total_elements - matched_count,
+            "ambiguous_match_count": ambiguous_count,
+            "candidate_tests": candidate_tests,
+            "matches_per_second": round(total_elements / match_seconds, 2) if match_seconds else total_elements,
+            "stamp": request.stamp,
+            "space_geometry_failures": space_geometry_failures,
+            "element_geometry_failures": element_geometry_failures,
+        }
+        benchmark = {
+            "load_seconds": round(load_seconds, 6),
+            "space_index_seconds": round(space_seconds, 6),
+            "topologic_cell_seconds": round(topologic_cell_seconds, 6),
+            "element_geometry_seconds": round(element_seconds, 6),
+            "match_seconds": round(match_seconds, 6),
+            "stamp_seconds": round(stamp_seconds, 6),
+            "total_seconds": round(elapsed_seconds, 6),
+        }
+        report = {
+            "success": True,
+            "message": "Topology roomstamp benchmark completed",
+            "summary": summary,
+            "benchmark": benchmark,
+            "topologicpy": topologicpy,
+            "request": request.model_dump(mode="json"),
+            "spaces": [_space_payload(space) for space in spaces],
+            "elements": element_results,
+            "stamped_outputs": stamped_outputs,
+        }
+        _write_json(report_path, report)
+
+        result = {
+            "success": True,
+            "message": "Topology roomstamp benchmark completed",
+            "summary": summary,
+            "benchmark": benchmark,
+            "report_path": report_path,
+            "stamped_outputs": stamped_outputs,
+            "storage": "filesystem",
+        }
+
+        if s3.is_enabled():
+            report_key = s3.normalize_output_key(request.output_file, "topology")
+            audit = s3.upload_and_audit(
+                report_path,
+                key=report_key,
+                operation="ifctopology_roomstamp",
+                worker=WORKER_NAME,
+                job_id=_current_job_id(),
+                parents=[("input", key) for key in input_keys],
+                metadata=summary,
+                content_type="application/json",
+            )
+            result.update({
+                "storage": "s3",
+                "bucket": s3.bucket_name(),
+                "output_key": report_key,
+                "report_path": f"s3://{s3.bucket_name()}/{report_key}",
+                "sha256": audit["sha256"],
+                "size_bytes": audit["size_bytes"],
+                "audit_id": audit["audit_id"],
+            })
+
+            uploaded_ifcs = []
+            for item in stamped_outputs:
+                key = s3.normalize_output_key(
+                    os.path.basename(item["output_path"]),
+                    "topology",
+                )
+                audit_ifc = s3.upload_and_audit(
+                    item["output_path"],
+                    key=key,
+                    operation="ifctopology_roomstamp_ifc",
+                    worker=WORKER_NAME,
+                    job_id=_current_job_id(),
+                    parents=[("input", s3.normalize_input_key(item["source_file"]))],
+                    metadata={
+                        "stamped_element_count": item["stamped_element_count"],
+                        "pset_name": request.pset_name,
+                    },
+                    content_type="application/x-step",
+                )
+                uploaded_ifcs.append({
+                    **item,
+                    "output_key": key,
+                    "output_path": f"s3://{s3.bucket_name()}/{key}",
+                    "sha256": audit_ifc["sha256"],
+                    "size_bytes": audit_ifc["size_bytes"],
+                    "audit_id": audit_ifc["audit_id"],
+                })
+            result["stamped_outputs"] = uploaded_ifcs
+
+        return result
+    except Exception:
+        logger.exception("Error during topology roomstamp benchmark")
+        raise
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)

--- a/shared/classes.py
+++ b/shared/classes.py
@@ -317,6 +317,103 @@ class IfcQtoRequest(BaseModel):
         return _validate_safe_path(v)
 
 
+class TopologyEngine(str, Enum):
+    AUTO = "auto"
+    BBOX = "bbox"
+    TOPOLOGICPY = "topologicpy"
+
+
+class TopologySampleStrategy(str, Enum):
+    BBOX_CENTROID = "bbox_centroid"
+    PLACEMENT = "placement"
+
+
+class IfcTopologyRequest(BaseModel):
+    """Request model for topology feasibility and room/zone stamping jobs."""
+
+    spatial_files: List[str] = Field(
+        ...,
+        min_length=1,
+        description="Architecture/spatial IFC files containing IfcSpace and optional IfcZone data",
+    )
+    element_files: List[str] = Field(
+        ...,
+        min_length=1,
+        description="MEP/target IFC files containing elements to classify or stamp",
+    )
+    output_file: str = Field(
+        default="topology_roomstamp_report.json",
+        description="JSON benchmark/report output filename",
+    )
+    element_query: str = Field(
+        default="IfcDistributionElement",
+        description="IfcOpenShell selector query for target elements",
+    )
+    space_query: str = Field(
+        default="IfcSpace",
+        description="IfcOpenShell selector query for room/space candidates",
+    )
+    include_zones: bool = Field(
+        default=True,
+        description="Include IfcZone assignments for matched spaces in report/stamps",
+    )
+    engine: TopologyEngine = Field(
+        default=TopologyEngine.AUTO,
+        description="Topology engine to benchmark. auto currently falls back to bbox when TopologicPy is absent.",
+    )
+    sample_strategy: TopologySampleStrategy = Field(
+        default=TopologySampleStrategy.BBOX_CENTROID,
+        description="Point used to classify target elements against spaces",
+    )
+    stamp: bool = Field(
+        default=False,
+        description="When true, write matched room/zone values into target IFC property sets",
+    )
+    pset_name: str = Field(
+        default="Pset_IfcPipelineRoomStamp",
+        description="Property set name used when stamp=true",
+    )
+    output_ifc_prefix: Optional[str] = Field(
+        default=None,
+        description="Optional output IFC path/prefix for stamped models",
+    )
+    max_elements: Optional[int] = Field(
+        default=None,
+        ge=1,
+        description="Optional cap for benchmark sampling large federated models",
+    )
+    tolerance: float = Field(
+        default=0.01,
+        ge=0,
+        description="Containment tolerance in model units",
+    )
+
+    @field_validator("spatial_files", "element_files")
+    @classmethod
+    def validate_file_lists(cls, v: List[str]) -> List[str]:
+        return [_validate_safe_path(path) for path in v]
+
+    @field_validator("output_file", "output_ifc_prefix")
+    @classmethod
+    def validate_output_paths(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        return _validate_safe_path(v)
+
+    @field_validator("pset_name")
+    @classmethod
+    def validate_pset_name(cls, v: str) -> str:
+        return _validate_safe_filename(v)
+
+    @field_validator("element_query", "space_query")
+    @classmethod
+    def validate_selector_queries(cls, v: str) -> str:
+        dangerous = set(";`$|")
+        if any(c in v for c in dangerous):
+            raise ValueError("Selector query contains invalid or dangerous characters")
+        return v
+
+
 class DownloadUrlRequest(BaseModel):
     url: str
     output_filename: Optional[str] = None  # Optional path to save the file to, if not provided it will use the filename from the URL

--- a/shared/classes.py
+++ b/shared/classes.py
@@ -329,7 +329,7 @@ class TopologySampleStrategy(str, Enum):
 
 
 class IfcTopologyRequest(BaseModel):
-    """Request model for topology feasibility and room/zone stamping jobs."""
+    """Request model for federated spatial relationship stamping jobs."""
 
     spatial_files: List[str] = Field(
         ...,
@@ -369,13 +369,17 @@ class IfcTopologyRequest(BaseModel):
         default=False,
         description="When true, write matched room/zone values into target IFC property sets",
     )
+    stamp_ambiguous: bool = Field(
+        default=False,
+        description="When false, elements matching multiple spaces are reported but not stamped",
+    )
     pset_name: str = Field(
         default="Pset_IfcPipelineRoomStamp",
         description="Property set name used when stamp=true",
     )
     output_ifc_prefix: Optional[str] = Field(
         default=None,
-        description="Optional output IFC path/prefix for stamped models",
+        description="Optional output IFC filename or subdirectory under output/topology for stamped models",
     )
     max_elements: Optional[int] = Field(
         default=None,

--- a/test_workers.py
+++ b/test_workers.py
@@ -46,6 +46,7 @@ QUEUE_NAMES = [
     "ifcdiff",
     "ifc5d",
     "ifc2json",
+    "ifctopology",
     "default" # Keep default for potential fallback or general tasks
 ]
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add dedicated `ifctopology-worker` for federating room/zone spatial relationships into IFC element property sets.
- Add `/ifctopology/roomstamp` API route, RQ queue wiring, health metadata, and Docker Compose service registration.
- Add request schema, worker README, and TopologicPy dependency bounds verified against current Linux cp311 wheels.
- Harden workflow behavior: chained `uploads/`, `output/`, and `examples/` references, configurable mount roots, deterministic `output/topology` outputs, richer stamped properties, and safe default skipping of ambiguous matches unless `stamp_ambiguous=true`.

## Verification
- `python3 -m py_compile shared/classes.py api-gateway/api-gateway.py ifctopology-worker/tasks.py test_workers.py`
- Pydantic schema validation for `IfcTopologyRequest` in an isolated temp install.
- Isolated runtime import check with `ifcopenshell==0.8.4`, `topologicpy>=0.9.43`, `pydantic`, `rq`, and `boto3`.
- Local capped dry-run smoke test using `shared/examples/Building-Architecture.ifc` + `Building-Hvac.ifc` with bbox engine.
- Local capped stamped-output smoke test confirmed Pset writing and skip counts.
- Local capped TopologicPy engine smoke test confirmed TopologicPy bbox-cell containment path.
- `pip download --only-binary ... --python-version 311 ... topologicpy topologic_core` confirmed cp311 manylinux wheels.
- Aikido MCP scan could not be run because no Aikido MCP server/resources are registered in this environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e4a17c8-20a0-4eec-a781-64aa5f12da8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e4a17c8-20a0-4eec-a781-64aa5f12da8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

