### PR TITLE
TGraph adoption + TopologicPy 0.9.52 KnowledgeGraph (RDF projection)

### DIFF
--- a/docker-compose.control-plane.yml
+++ b/docker-compose.control-plane.yml
@@ -139,7 +139,10 @@ services:
       resources:
         limits:
           cpus: '2.0'
-          memory: 3G
+          # Filer + S3 + volume server in one process; the needle-map index and
+          # filer store grow with object count. Was pegged at ~98% of 3G, so
+          # raised to 5G (host has ~6G available headroom of 33G total).
+          memory: 5G
 
   # One-shot: wait for SeaweedFS, create the bucket + enable versioning.
   seaweedfs-setup:

--- a/tests/test_federated_relationships.py
+++ b/tests/test_federated_relationships.py
@@ -1,0 +1,79 @@
+"""Unit tests for FederatedRelationships geometric classification (cross-discipline edges)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "topologicpy-worker"))
+
+from ingest_scripts.FederatedRelationships import (
+    aabb_relation,
+    classify_pair,
+    discipline,
+)
+
+
+def _el(gid, cls, aabb):
+    return {"gid": gid, "ifc_class": cls, "discipline": discipline(cls),
+            "aabb": aabb, "centroid": ((aabb[0]+aabb[3])/2, (aabb[1]+aabb[4])/2, (aabb[2]+aabb[5])/2)}
+
+
+# --- discipline tagging -----------------------------------------------------
+def test_discipline_tags():
+    assert discipline("IfcDuctSegment") == "mep"
+    assert discipline("IfcWall") == "architectural"
+    assert discipline("IfcColumn") == "structural"
+    assert discipline("IfcSpace") == "spatial"
+
+
+# --- aabb math --------------------------------------------------------------
+def test_aabb_overlap_and_gap():
+    a = (0, 0, 0, 1, 1, 1)
+    assert aabb_relation(a, (0.5, 0.5, 0.5, 2, 2, 2))["overlaps"] is True
+    r = aabb_relation(a, (2, 0, 0, 3, 1, 1))  # 1m gap on x
+    assert r["overlaps"] is False and abs(r["gap"] - 1.0) < 1e-9
+
+
+# --- classification ---------------------------------------------------------
+def test_penetrates_duct_through_wall():
+    duct = _el("D", "IfcDuctSegment", (0, 0, 2, 5, 0.3, 2.3))   # long run along x
+    wall = _el("W", "IfcWall", (2, -0.1, 0, 2.2, 3, 3))         # thin wall the duct crosses
+    res = classify_pair(duct, wall)
+    assert res["type"] == "penetrates"
+    assert "penetration_m" in res["evidence"]
+
+
+def test_sits_in_space():
+    box = _el("B", "IfcDuctSegment", (1, 1, 1, 1.2, 1.2, 1.2))  # mep element
+    space = _el("S", "IfcSpace", (0, 0, 0, 4, 4, 3))            # centroid inside
+    res = classify_pair(box, space)
+    assert res["type"] == "sits_in"
+
+
+def test_mounted_on_top_of_slab():
+    equip = _el("E", "IfcFlowTerminal", (1, 1, 3.0, 1.5, 1.5, 3.5))  # sits on slab top z=3
+    slab = _el("SL", "IfcSlab", (0, 0, 2.8, 5, 5, 3.0))
+    res = classify_pair(equip, slab)
+    assert res["type"] == "mounted_on"
+    assert res["evidence"]["contact"] == "on_top"
+
+
+def test_intersects_generic_cross_discipline():
+    pipe = _el("P", "IfcFlowTerminal", (0, 0, 0, 1, 1, 1))
+    col = _el("C", "IfcColumn", (0.5, 0.5, 0.5, 1.5, 1.5, 1.5))
+    res = classify_pair(pipe, col)
+    assert res["type"] in {"intersects", "mounted_on"}  # overlap → a cross-discipline relation
+
+
+def test_within_clearance():
+    duct = _el("D", "IfcDuctSegment", (0, 0, 0, 1, 1, 1))
+    wall = _el("W", "IfcWall", (1.02, 0, 0, 2, 1, 1))  # 20mm gap
+    res = classify_pair(duct, wall, clearance=0.05)
+    assert res["type"] == "within_clearance"
+
+
+def test_same_discipline_skipped():
+    a = _el("A", "IfcWall", (0, 0, 0, 1, 1, 1))
+    b = _el("B", "IfcSlab", (0.5, 0.5, 0.5, 2, 2, 2))  # both architectural
+    assert classify_pair(a, b) is None

--- a/tests/test_wall_hosting.py
+++ b/tests/test_wall_hosting.py
@@ -1,0 +1,109 @@
+"""Unit tests for the WallHosting ingest script (door→wall ``hosted_by`` edge)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "topologicpy-worker"))
+
+import ingest_scripts.WallHosting as wh
+from ingest_scripts.WallHosting import Ingester, host_wall_global_id
+
+
+# --- fake IFC objects (mirror test_egress_door_linking style) ---------------
+
+
+class _Wall:
+    def __init__(self, gid, cls="IfcWall"):
+        self.GlobalId = gid
+        self._c = cls
+
+    def is_a(self):
+        return self._c
+
+
+class _VoidRel:
+    def __init__(self, wall):
+        self.RelatingBuildingElement = wall
+
+
+class _Opening:
+    def __init__(self, voids):
+        self.VoidsElements = voids
+
+
+class _FillRel:
+    def __init__(self, opening):
+        self.RelatedOpeningElement = opening
+
+
+class _Door:
+    def __init__(self, gid, fills, cls="IfcDoor"):
+        self.GlobalId = gid
+        self.FillsVoids = fills
+        self._c = cls
+
+    def is_a(self):
+        return self._c
+
+
+def _hosted_door(door_gid="D1", wall_gid="W1"):
+    wall = _Wall(wall_gid)
+    opening = _Opening([_VoidRel(wall)])
+    return _Door(door_gid, [_FillRel(opening)])
+
+
+# --- host_wall_global_id ----------------------------------------------------
+
+
+def test_host_wall_global_id_resolves_wall():
+    assert host_wall_global_id(_hosted_door("D1", "W9")) == "W9"
+
+
+def test_host_wall_global_id_none_when_unhosted():
+    assert host_wall_global_id(_Door("D2", [])) is None
+
+
+def test_host_wall_global_id_ignores_non_wall_host():
+    opening = _Opening([_VoidRel(_Wall("S1", cls="IfcSlab"))])
+    assert host_wall_global_id(_Door("D3", [_FillRel(opening)])) is None
+
+
+# --- Ingester ---------------------------------------------------------------
+
+
+def test_ingester_emits_hosted_by(monkeypatch):
+    doors = [_hosted_door("D1", "W1"), _hosted_door("D2", "W2"), _Door("D3", [])]
+    monkeypatch.setattr(wh.ifcopenshell, "open", lambda _p: object())
+    monkeypatch.setattr(wh, "safe_by_type", lambda _ifc, _q: doors)
+
+    ing = Ingester([Path("model.ifc")], logging.getLogger("test"))
+    ing.extract()
+    rels = ing.get_relationships()
+
+    assert len(rels) == 2
+    by_door = {r["subject_global_id"]: r for r in rels}
+    assert by_door["D1"]["object_global_id"] == "W1"
+    assert by_door["D2"]["object_global_id"] == "W2"
+    assert all(r["relationship_type"] == "hosted_by" for r in rels)
+    assert all(r["relationship_family"] == "spatial" for r in rels)
+    assert all(r["confidence"] == 1.0 for r in rels)
+    assert all(r["source_kind"] == "topologic_ingest_WallHosting" for r in rels)
+
+    summary = ing.get_summary()
+    assert summary["doors_total"] == 3
+    assert summary["hosted_doors"] == 2
+    assert summary["unresolved_doors"] == 1
+
+
+def test_ingester_dedupes_pairs(monkeypatch):
+    """The same (door, wall) pair is emitted once — replay/idempotency parity."""
+    monkeypatch.setattr(wh.ifcopenshell, "open", lambda _p: object())
+    monkeypatch.setattr(
+        wh, "safe_by_type", lambda _ifc, _q: [_hosted_door("D1", "W1"), _hosted_door("D1", "W1")]
+    )
+    ing = Ingester([Path("m.ifc")], logging.getLogger("test"))
+    ing.extract()
+    assert len(ing.get_relationships()) == 1

--- a/tests/test_wall_hosting.py
+++ b/tests/test_wall_hosting.py
@@ -9,7 +9,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "topologicpy-worker"))
 
 import ingest_scripts.WallHosting as wh
-from ingest_scripts.WallHosting import Ingester, host_wall_global_id
+from ingest_scripts.WallHosting import Ingester, host_element_of, host_wall_global_id
 
 
 # --- fake IFC objects (mirror test_egress_door_linking style) ---------------
@@ -66,16 +66,29 @@ def test_host_wall_global_id_none_when_unhosted():
     assert host_wall_global_id(_Door("D2", [])) is None
 
 
-def test_host_wall_global_id_ignores_non_wall_host():
-    opening = _Opening([_VoidRel(_Wall("S1", cls="IfcSlab"))])
-    assert host_wall_global_id(_Door("D3", [_FillRel(opening)])) is None
+def _door_hosted_in(door_gid, host_gid, host_cls):
+    opening = _Opening([_VoidRel(_Wall(host_gid, cls=host_cls))])
+    return _Door(door_gid, [_FillRel(opening)])
+
+
+def test_non_wall_host_resolves_but_wall_compat_is_none():
+    # the SBUF case: 14 doors are voided into an IfcCovering, not a wall
+    door = _door_hosted_in("D3", "C1", "IfcCovering")
+    assert host_wall_global_id(door) is None              # wall-only compat: None
+    assert host_element_of(door) == ("C1", "IfcCovering")  # broadened: resolves the actual host
+
+
+def test_host_element_prefers_wall_over_non_wall():
+    op = _Opening([_VoidRel(_Wall("C1", cls="IfcCovering")), _VoidRel(_Wall("W1", cls="IfcWall"))])
+    assert host_element_of(_Door("D", [_FillRel(op)])) == ("W1", "IfcWall")
 
 
 # --- Ingester ---------------------------------------------------------------
 
 
-def test_ingester_emits_hosted_by(monkeypatch):
-    doors = [_hosted_door("D1", "W1"), _hosted_door("D2", "W2"), _Door("D3", [])]
+def test_ingester_emits_hosted_by_incl_non_wall(monkeypatch):
+    # D1 hosted in a wall, D2 in a covering (the SBUF gap), D3 unhosted
+    doors = [_hosted_door("D1", "W1"), _door_hosted_in("D2", "C2", "IfcCovering"), _Door("D3", [])]
     monkeypatch.setattr(wh.ifcopenshell, "open", lambda _p: object())
     monkeypatch.setattr(wh, "safe_by_type", lambda _ifc, _q: doors)
 
@@ -86,15 +99,18 @@ def test_ingester_emits_hosted_by(monkeypatch):
     assert len(rels) == 2
     by_door = {r["subject_global_id"]: r for r in rels}
     assert by_door["D1"]["object_global_id"] == "W1"
-    assert by_door["D2"]["object_global_id"] == "W2"
+    assert by_door["D1"]["evidence"]["isWall"] is True
+    assert by_door["D2"]["object_global_id"] == "C2"
+    assert by_door["D2"]["evidence"]["hostClass"] == "IfcCovering"
+    assert by_door["D2"]["evidence"]["isWall"] is False
     assert all(r["relationship_type"] == "hosted_by" for r in rels)
-    assert all(r["relationship_family"] == "spatial" for r in rels)
     assert all(r["confidence"] == 1.0 for r in rels)
-    assert all(r["source_kind"] == "topologic_ingest_WallHosting" for r in rels)
 
     summary = ing.get_summary()
     assert summary["doors_total"] == 3
     assert summary["hosted_doors"] == 2
+    assert summary["hosted_in_wall"] == 1
+    assert summary["hosted_in_non_wall"] == 1
     assert summary["unresolved_doors"] == 1
 
 

--- a/topologicpy-worker/ingest_scripts/FederatedRelationships.py
+++ b/topologicpy-worker/ingest_scripts/FederatedRelationships.py
@@ -1,0 +1,242 @@
+"""Federated cross-model spatial relationships — geometry-derived, replayable recipe.
+
+The federated graph's reason for being: relationships that exist in **no single IFC** because
+discipline models are siloed (IFC `IfcRel*` are intra-file). When models are projected into one
+revision keyed by `(projectId, revisionId, globalId)`, geometry reveals cross-discipline relations:
+
+  * ``penetrates``      — an MEP run passes through a building element (duct/pipe through wall/slab)
+  * ``intersects``      — generic solid overlap between two disciplines ("crosses")
+  * ``sits_in``         — an element's body falls inside an IfcSpace
+  * ``mounted_on``      — an element rests on / is fixed against a host surface (equipment on wall/slab)
+  * ``within_clearance``— two cross-discipline elements are closer than a clearance threshold
+
+These are **assumed** candidate evidence (ADR-006): geometry-derived, source-kind
+``deterministic_geometry``, replayable (same revisions + recipe + engine ⇒ same edge set), and
+review-only until confirmed. Sibling to ``WallHosting`` (the explicit, intra-file ``hosted_by``
+instance) — together they are the federated relationship family.
+
+v1 is an **AABB broad-phase** classifier (axis-aligned bounding boxes from IfcOpenShell world
+geometry) + class-aware rules — deterministic and cheap. Precise TopologicPy Boolean narrow-phase
+is a refinement; the ``assumed`` state already reflects that these need confirmation.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import ifcopenshell
+import ifcopenshell.geom
+
+from ingest_scripts import Ingester as _Base, Relationship, safe_by_type
+
+# --- class taxonomy ---------------------------------------------------------
+BUILDING_HOSTS = {
+    "IfcWall", "IfcWallStandardCase", "IfcWallElementedCase", "IfcSlab", "IfcRoof",
+    "IfcColumn", "IfcBeam", "IfcMember", "IfcPlate", "IfcCovering", "IfcCurtainWall",
+}
+MEP_RUNS = {
+    "IfcPipeSegment", "IfcDuctSegment", "IfcCableCarrierSegment", "IfcCableSegment",
+    "IfcFlowSegment", "IfcPipeFitting", "IfcDuctFitting", "IfcFlowFitting", "IfcCableCarrierFitting",
+}
+MEP_EQUIP = {
+    "IfcFlowTerminal", "IfcEnergyConversionDevice", "IfcDistributionControlElement",
+    "IfcFlowController", "IfcFlowMovingDevice", "IfcSanitaryTerminal", "IfcLightFixture",
+    "IfcAirTerminal", "IfcElectricAppliance", "IfcOutlet", "IfcDistributionElement",
+}
+SPACES = {"IfcSpace", "IfcSpatialZone"}
+
+# coarse discipline tag from class — cross-discipline is the federated value we want
+_DISCIPLINE = [
+    (MEP_RUNS | MEP_EQUIP, "mep"),
+    ({"IfcColumn", "IfcBeam", "IfcMember", "IfcPlate", "IfcFooting", "IfcPile"}, "structural"),
+    (BUILDING_HOSTS, "architectural"),
+    (SPACES, "spatial"),
+]
+
+
+def discipline(ifc_class: str) -> str:
+    for classes, disc in _DISCIPLINE:
+        if ifc_class in classes:
+            return disc
+    return "other"
+
+
+# --- geometry helpers (AABB + centroid in world coords) ---------------------
+def _settings():
+    s = ifcopenshell.geom.settings()
+    try:
+        s.set(s.USE_WORLD_COORDS, True)
+    except Exception:
+        pass
+    return s
+
+
+def aabb_of(element, settings) -> Optional[Tuple[float, ...]]:
+    """World-coord axis-aligned bounding box (minx,miny,minz,maxx,maxy,maxz) or None."""
+    try:
+        shape = ifcopenshell.geom.create_shape(settings, element)
+        verts = shape.geometry.verts
+        if not verts:
+            return None
+        xs, ys, zs = verts[0::3], verts[1::3], verts[2::3]
+        return (min(xs), min(ys), min(zs), max(xs), max(ys), max(zs))
+    except Exception:
+        return None
+
+
+def _overlap_1d(amin, amax, bmin, bmax) -> float:
+    return min(amax, bmax) - max(amin, bmin)  # >0 overlap, <0 gap
+
+
+def aabb_relation(a: Tuple[float, ...], b: Tuple[float, ...]) -> Dict[str, Any]:
+    """Per-axis overlap (negative = gap) + derived overlap box / gap metrics."""
+    ox = _overlap_1d(a[0], a[3], b[0], b[3])
+    oy = _overlap_1d(a[1], a[4], b[1], b[4])
+    oz = _overlap_1d(a[2], a[5], b[2], b[5])
+    overlaps = ox > 0 and oy > 0 and oz > 0
+    gap = 0.0 if overlaps else max(0.0, max(-ox, -oy, -oz))
+    return {"ox": ox, "oy": oy, "oz": oz, "overlaps": overlaps, "gap": gap,
+            "overlap_min_dim": min(ox, oy, oz) if overlaps else 0.0}
+
+
+def _thinnest(a: Tuple[float, ...]) -> float:
+    return min(a[3] - a[0], a[4] - a[1], a[5] - a[2])
+
+
+# --- classification (pure, unit-testable with fake dicts) -------------------
+def classify_pair(src: Dict[str, Any], tgt: Dict[str, Any], *, clearance: float = 0.05) -> Optional[Dict[str, Any]]:
+    """Classify the geometric relation src→tgt. Returns {type, confidence, evidence} or None.
+
+    src/tgt are dicts: {gid, ifc_class, discipline, aabb, centroid}. One predicate per pair
+    (highest-priority match). Only cross-discipline pairs are emitted (the federated value)."""
+    if src["discipline"] == tgt["discipline"]:
+        return None
+    sc, tc = src["ifc_class"], tgt["ifc_class"]
+
+    # sits_in: any element whose centroid falls inside a space's AABB
+    if tc in SPACES:
+        cx, cy, cz = src["centroid"]
+        ta = tgt["aabb"]
+        if ta[0] <= cx <= ta[3] and ta[1] <= cy <= ta[4] and ta[2] <= cz <= ta[5]:
+            return {"type": "sits_in", "confidence": 0.8,
+                    "evidence": {"method": "aabb_centroid_in_space"}}
+        return None
+    if sc in SPACES:
+        return None  # space as subject handled from the element side
+
+    rel = aabb_relation(src["aabb"], tgt["aabb"])
+    sa, ta = src["aabb"], tgt["aabb"]
+    tol = max(clearance, 0.05)
+
+    # penetrates: an MEP run overlapping a building host (passes through it)
+    if rel["overlaps"] and sc in MEP_RUNS and tc in BUILDING_HOSTS:
+        return {"type": "penetrates", "confidence": 0.8,
+                "evidence": {"method": "aabb_overlap", "penetration_m": round(rel["overlap_min_dim"], 4),
+                             "host_thickness_m": round(_thinnest(ta), 4)}}
+
+    # mounted_on: element resting ON TOP of a host surface (z-contact within tol, xy overlap).
+    # (Wall-face mounting and embedded fixings are a narrow-phase refinement.)
+    if tc in BUILDING_HOSTS and sc not in BUILDING_HOSTS:
+        if abs(sa[2] - ta[5]) <= tol and rel["ox"] > 0 and rel["oy"] > 0:
+            return {"type": "mounted_on", "confidence": 0.75,
+                    "evidence": {"method": "aabb_contact", "contact": "on_top"}}
+
+    # generic cross-discipline solid overlap ("crosses")
+    if rel["overlaps"]:
+        return {"type": "intersects", "confidence": 0.7,
+                "evidence": {"method": "aabb_overlap", "overlap_min_dim_m": round(rel["overlap_min_dim"], 4)}}
+
+    # within_clearance: cross-discipline near-miss
+    if 0 < rel["gap"] <= clearance:
+        return {"type": "within_clearance", "confidence": 0.6,
+                "evidence": {"method": "aabb_gap", "gap_m": round(rel["gap"], 4)}}
+    return None
+
+
+class Ingester(_Base):
+    SCRIPT_NAME = "FederatedRelationships"
+    DESCRIPTION = "Derive cross-discipline spatial relationships (penetrates/intersects/sits_in/mounted_on) across federated models"
+
+    def __init__(self, ifc_files: List[Path], log: logging.Logger, clearance: float = 0.05, grid_m: float = 3.0):
+        """Geometry-derived cross-model relationships from federated IFC models.
+
+        :param clearance: max gap (m) for a within_clearance relation.
+        :param grid_m: broad-phase grid cell size (m) for the target spatial index.
+        """
+        super().__init__(ifc_files, log)
+        self.clearance = float(clearance)
+        self.grid_m = float(grid_m)
+
+    def _collect(self, ifc, settings) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        for e in safe_by_type(ifc, "IfcProduct"):
+            gid = getattr(e, "GlobalId", None)
+            cls = e.is_a()
+            if not gid or cls in {"IfcOpeningElement", "IfcOpeningStandardCase"}:
+                continue
+            a = aabb_of(e, settings)
+            if a is None:
+                continue
+            out.append({"gid": gid, "ifc_class": cls, "discipline": discipline(cls),
+                        "aabb": a, "centroid": ((a[0]+a[3])/2, (a[1]+a[4])/2, (a[2]+a[5])/2)})
+        return out
+
+    def extract(self) -> None:
+        t0 = time.time()
+        settings = _settings()
+        elems: List[Dict[str, Any]] = []
+        for ifc_path in self.ifc_files:
+            self.log.info("federated_rel: geometry from %s", ifc_path.name)
+            elems.extend(self._collect(ifcopenshell.open(str(ifc_path)), settings))
+
+        # targets = hosts + spaces (what others relate TO); grid-index them for broad-phase
+        targets = [e for e in elems if e["ifc_class"] in BUILDING_HOSTS or e["ifc_class"] in SPACES]
+        grid: Dict[Tuple[int, int], List[int]] = {}
+        g = self.grid_m
+        for idx, t in enumerate(targets):
+            a = t["aabb"]
+            for cx in range(int(a[0] // g), int(a[3] // g) + 1):
+                for cy in range(int(a[1] // g), int(a[4] // g) + 1):
+                    grid.setdefault((cx, cy), []).append(idx)
+
+        seen: set = set()
+        emitted = 0
+        by_type: Dict[str, int] = {}
+        for src in sorted(elems, key=lambda e: e["gid"]):
+            a = src["aabb"]
+            cand: set = set()
+            for cx in range(int(a[0] // g), int(a[3] // g) + 1):
+                for cy in range(int(a[1] // g), int(a[4] // g) + 1):
+                    cand.update(grid.get((cx, cy), ()))
+            for ti in sorted(cand):
+                tgt = targets[ti]
+                if tgt["gid"] == src["gid"]:
+                    continue
+                res = classify_pair(src, tgt, clearance=self.clearance)
+                if not res:
+                    continue
+                key = (src["gid"], tgt["gid"], res["type"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                self._relationships.append(Relationship(
+                    subject_global_id=src["gid"],
+                    object_global_id=tgt["gid"],
+                    relationship_family="spatial",
+                    relationship_type=res["type"],
+                    confidence=res["confidence"],
+                    source_kind="topologic_ingest_FederatedRelationships",
+                    evidence={**res["evidence"], "subjectClass": src["ifc_class"],
+                              "objectClass": tgt["ifc_class"],
+                              "subjectDiscipline": src["discipline"],
+                              "objectDiscipline": tgt["discipline"], "state": "assumed"},
+                ))
+                by_type[res["type"]] = by_type.get(res["type"], 0) + 1
+                emitted += 1
+
+        self._summary = {"elements_with_geometry": len(elems), "targets": len(targets),
+                         "relationships": emitted, "by_type": by_type,
+                         "duration_ms": int((time.time() - t0) * 1000)}

--- a/topologicpy-worker/ingest_scripts/FederatedRelationships.py
+++ b/topologicpy-worker/ingest_scripts/FederatedRelationships.py
@@ -23,6 +23,7 @@ is a refinement; the ``assumed`` state already reflects that these need confirma
 from __future__ import annotations
 
 import logging
+import os
 import time
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -64,21 +65,42 @@ def discipline(ifc_class: str) -> str:
     return "other"
 
 
-# --- geometry helpers (AABB + centroid in world coords) ---------------------
+# --- geometry helpers --------------------------------------------------------
 def _settings():
-    s = ifcopenshell.geom.settings()
-    try:
-        s.set(s.USE_WORLD_COORDS, True)
-    except Exception:
-        pass
-    return s
+    # LOCAL coords (no USE_WORLD_COORDS): lets the iterator reuse tessellation across identical
+    # representations (~270× faster on SBUF). World AABB is computed by transforming the local
+    # bbox corners with each element's placement matrix (_world_aabb).
+    return ifcopenshell.geom.settings()
+
+
+def _world_aabb(verts, m) -> Tuple[float, ...]:
+    """World AABB from local ``verts`` + a 16-float column-major placement matrix ``m``.
+
+    Transforms the 8 corners of the local bbox (not every vertex) — cheap and exact for AABB.
+    """
+    xs, ys, zs = verts[0::3], verts[1::3], verts[2::3]
+    lx0, ly0, lz0, lx1, ly1, lz1 = min(xs), min(ys), min(zs), max(xs), max(ys), max(zs)
+    wx: List[float] = []
+    wy: List[float] = []
+    wz: List[float] = []
+    for x in (lx0, lx1):
+        for y in (ly0, ly1):
+            for z in (lz0, lz1):
+                wx.append(m[0] * x + m[4] * y + m[8] * z + m[12])
+                wy.append(m[1] * x + m[5] * y + m[9] * z + m[13])
+                wz.append(m[2] * x + m[6] * y + m[10] * z + m[14])
+    return (min(wx), min(wy), min(wz), max(wx), max(wy), max(wz))
 
 
 def aabb_of(element, settings) -> Optional[Tuple[float, ...]]:
-    """World-coord axis-aligned bounding box (minx,miny,minz,maxx,maxy,maxz) or None."""
+    """World-coord AABB for a single element (utility / fallback; the main path uses the iterator)."""
     try:
-        shape = ifcopenshell.geom.create_shape(settings, element)
-        verts = shape.geometry.verts
+        s = ifcopenshell.geom.settings()
+        try:
+            s.set(s.USE_WORLD_COORDS, True)
+        except Exception:
+            pass
+        verts = ifcopenshell.geom.create_shape(s, element).geometry.verts
         if not verts:
             return None
         xs, ys, zs = verts[0::3], verts[1::3], verts[2::3]
@@ -160,28 +182,50 @@ class Ingester(_Base):
     SCRIPT_NAME = "FederatedRelationships"
     DESCRIPTION = "Derive cross-discipline spatial relationships (penetrates/intersects/sits_in/mounted_on) across federated models"
 
-    def __init__(self, ifc_files: List[Path], log: logging.Logger, clearance: float = 0.05, grid_m: float = 3.0):
+    def __init__(self, ifc_files: List[Path], log: logging.Logger, clearance: float = 0.05,
+                 grid_m: float = 3.0, num_threads: int = 0):
         """Geometry-derived cross-model relationships from federated IFC models.
 
         :param clearance: max gap (m) for a within_clearance relation.
         :param grid_m: broad-phase grid cell size (m) for the target spatial index.
+        :param num_threads: geometry-iterator threads (0 = auto: cpu_count-1).
         """
         super().__init__(ifc_files, log)
         self.clearance = float(clearance)
         self.grid_m = float(grid_m)
+        self.num_threads = int(num_threads) or max(1, (os.cpu_count() or 2) - 1)
 
     def _collect(self, ifc, settings) -> List[Dict[str, Any]]:
+        """AABBs via the multi-threaded geometry iterator — initializes the kernel once and
+        streams (vs per-element ``create_shape``, which re-inits per call; ~10–20× faster)."""
+        skip = {"IfcOpeningElement", "IfcOpeningStandardCase"}
+        by_gid = {
+            e.GlobalId: e.is_a()
+            for e in safe_by_type(ifc, "IfcProduct")
+            if getattr(e, "GlobalId", None) and e.is_a() not in skip
+        }
         out: List[Dict[str, Any]] = []
-        for e in safe_by_type(ifc, "IfcProduct"):
-            gid = getattr(e, "GlobalId", None)
-            cls = e.is_a()
-            if not gid or cls in {"IfcOpeningElement", "IfcOpeningStandardCase"}:
-                continue
-            a = aabb_of(e, settings)
-            if a is None:
-                continue
-            out.append({"gid": gid, "ifc_class": cls, "discipline": discipline(cls),
-                        "aabb": a, "centroid": ((a[0]+a[3])/2, (a[1]+a[4])/2, (a[2]+a[5])/2)})
+        try:
+            it = ifcopenshell.geom.iterator(settings, ifc, self.num_threads)
+            if not it.initialize():
+                return out
+        except Exception:
+            self.log.warning("federated_rel: geometry iterator unavailable", exc_info=True)
+            return out
+        while True:
+            shape = it.get()
+            gid = getattr(shape, "guid", None)
+            cls = by_gid.get(gid)
+            if cls:
+                verts = shape.geometry.verts
+                if verts:
+                    mat = shape.transformation.matrix
+                    m = list(getattr(mat, "data", mat))
+                    a = _world_aabb(verts, m)
+                    out.append({"gid": gid, "ifc_class": cls, "discipline": discipline(cls),
+                                "aabb": a, "centroid": ((a[0]+a[3])/2, (a[1]+a[4])/2, (a[2]+a[5])/2)})
+            if not it.next():
+                break
         return out
 
     def extract(self) -> None:

--- a/topologicpy-worker/ingest_scripts/KnowledgeGraphExport.py
+++ b/topologicpy-worker/ingest_scripts/KnowledgeGraphExport.py
@@ -1,0 +1,273 @@
+"""Knowledge Graph (RDF) export — opt-in semantic projection from the TGraph.
+
+TopologicPy 0.9.52 added a ``KnowledgeGraph`` module that turns a TGraph into RDF
+triples linked to BOT (Building Topology Ontology), Brick, IFC-OWL, GeoSPARQL and
+PROV. This script is the worker-side entry point: it builds the same TGraph the LPG
+scripts use (via :mod:`ingest_scripts.topograph`), converts it to a KnowledgeGraph,
+and emits a Turtle (``.ttl``) artifact alongside the standard relationships JSON.
+
+Design — RDF is a *derived projection*, not a backend (the LPG/Neo4j graph stays the
+system of record):
+
+  * ``reason``  — run RDFS + BOT inference; report how many triples were materialized.
+  * ``merge``   — when several models are passed, union them into one semantic graph
+                  (cross-model federation by shared identity/vocabulary, not geometry).
+  * ``materialize`` — when reasoning, emit the *inferred element->element* edges back
+                  into the relationships JSON so cde projects them into the LPG with
+                  ``source_kind="topologic_reason_rdfs"`` (review-only, ``state=assumed``).
+                  RDFS *type* assertions are node-level (not element<->element edges) so
+                  cde's relationship ingest would skip them — they are counted in the
+                  summary instead of emitted.
+
+GlobalId identity: TopologicPy's ``Ontology._uri_for_topology`` mints an instance IRI
+from the dictionary key ``ifc_guid`` first. The topograph adapter populates
+``IFC_global_id``; :meth:`_set_guid_keys` copies it to ``ifc_guid`` so every instance
+gets a GlobalId-unique IRI — without this, instances collapse by class label and a
+merge over-deduplicates.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from ingest_scripts import Ingester as _Base, Relationship
+from ingest_scripts import topograph
+
+# Predicates that are schema/annotation, never instance-to-instance edges.
+_NON_EDGE_PRED = re.compile(
+    r"(22-rdf-syntax-ns#type|rdf-schema#|2002/07/owl#|/skos/|/dc/|/dcterms/|vann#|#IFC_)",
+    re.IGNORECASE,
+)
+_GUID_PRED = re.compile(r"(ifc_guid|IFC_global_id|globalId|#guid$)", re.IGNORECASE)
+
+
+def _localname(uri: str) -> str:
+    s = str(uri)
+    for sep in ("#", "/"):
+        if sep in s:
+            s = s.rsplit(sep, 1)[-1]
+    return s
+
+
+class Ingester(_Base):
+    SCRIPT_NAME = "KnowledgeGraphExport"
+    DESCRIPTION = (
+        "Export an RDF/Turtle KnowledgeGraph (BOT/Brick/IFC-OWL) from the TGraph; "
+        "optional RDFS+BOT reasoning and multi-model semantic merge (0.9.52)."
+    )
+
+    def __init__(
+        self,
+        ifc_files: List[Path],
+        log: logging.Logger,
+        reason: bool = False,
+        merge: bool = True,
+        include_bot: bool = True,
+        materialize: bool = True,
+        fmt: str = "turtle",
+    ):
+        """Convert each model's TGraph into a KnowledgeGraph (RDF) and emit Turtle.
+
+        :param reason: run RDFS + BOT inference and report materialized triples.
+        :param merge: when multiple input files, union them into one semantic graph.
+        :param include_bot: link instances to Building Topology Ontology concepts.
+        :param materialize: emit inferred element->element edges into the LPG pipeline.
+        :param fmt: RDF serialization format (currently "turtle").
+        """
+        super().__init__(ifc_files, log)
+        self.reason = bool(reason)
+        self.merge = bool(merge)
+        self.include_bot = bool(include_bot)
+        self.materialize = bool(materialize)
+        self.fmt = str(fmt or "turtle")
+        self._artifacts: List[Tuple[str, Any, str]] = []
+
+    # --- helpers -------------------------------------------------------------
+    def _set_guid_keys(self, g) -> int:
+        """Copy ``IFC_global_id`` -> ``ifc_guid`` on every vertex so Ontology mints
+        GlobalId-unique IRIs. Returns the number of vertices stamped."""
+        n = 0
+        try:
+            from topologicpy.TGraph import TGraph
+            verts = TGraph.Vertices(g)
+        except Exception:
+            self.log.warning("kg_export: could not enumerate vertices for guid keying", exc_info=True)
+            return 0
+        for rec in verts:
+            d = rec.get("dictionary") if isinstance(rec, dict) else None
+            if not isinstance(d, dict):
+                continue
+            gid = d.get("IFC_global_id") or d.get("GlobalId")
+            if gid and not d.get("ifc_guid"):
+                d["ifc_guid"] = gid
+                if d.get("IFC_name") and not d.get("label"):
+                    d["label"] = d["IFC_name"]
+                if d.get("IFC_type") and not d.get("ifc_class"):
+                    d["ifc_class"] = d["IFC_type"]
+                n += 1
+        return n
+
+    @staticmethod
+    def _triple_count(ttl: str) -> Optional[int]:
+        try:
+            import rdflib
+            rg = rdflib.Graph()
+            rg.parse(data=ttl, format="turtle")
+            return len(rg)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _prefixes(ttl: str) -> List[str]:
+        out = []
+        for line in ttl.splitlines():
+            line = line.strip()
+            if line.startswith("@prefix"):
+                m = re.match(r"@prefix\s+([A-Za-z0-9_-]+):", line)
+                if m:
+                    out.append(m.group(1))
+            elif not line.startswith("@") and line:
+                break
+        return out
+
+    def _iri_to_guid(self, ttl: str) -> Dict[str, str]:
+        """Map each subject IRI to its GlobalId by reading the guid property triples."""
+        mapping: Dict[str, str] = {}
+        try:
+            import rdflib
+            rg = rdflib.Graph()
+            rg.parse(data=ttl, format="turtle")
+            for s, p, o in rg:
+                if _GUID_PRED.search(str(p)) and isinstance(o, rdflib.Literal):
+                    mapping[str(s)] = str(o)
+        except Exception:
+            self.log.warning("kg_export: iri->guid mapping failed", exc_info=True)
+        return mapping
+
+    def _materialize_edges(self, ttl: str, source_kind: str) -> int:
+        """Emit inferred element->element edges (both endpoints map to a GlobalId)."""
+        guid = self._iri_to_guid(ttl)
+        if not guid:
+            return 0
+        emitted = 0
+        seen: set = set()
+        try:
+            import rdflib
+            rg = rdflib.Graph()
+            rg.parse(data=ttl, format="turtle")
+            for s, p, o in rg:
+                ps = str(p)
+                if _NON_EDGE_PRED.search(ps) or _GUID_PRED.search(ps):
+                    continue
+                ss, os_ = str(s), str(o)
+                sg, og = guid.get(ss), guid.get(os_)
+                if not sg or not og or sg == og:
+                    continue
+                rtype = _localname(ps) or "related"
+                key = (sg, og, rtype)
+                if key in seen:
+                    continue
+                seen.add(key)
+                self._relationships.append(Relationship(
+                    subject_global_id=sg,
+                    object_global_id=og,
+                    relationship_family="semantic",
+                    relationship_type=rtype,
+                    confidence=1.0,
+                    source_kind=source_kind,
+                    evidence={"predicate": ps, "profile": "rdfs",
+                              "bot": self.include_bot, "state": "assumed"},
+                ))
+                emitted += 1
+        except Exception:
+            self.log.warning("kg_export: edge materialization failed", exc_info=True)
+        return emitted
+
+    # --- main ----------------------------------------------------------------
+    def extract(self) -> None:
+        t0 = time.time()
+        try:
+            from topologicpy.KnowledgeGraph import KnowledgeGraph
+        except Exception as exc:  # pragma: no cover - depends on topologicpy>=0.9.52
+            raise RuntimeError(
+                "KnowledgeGraphExport requires topologicpy>=0.9.52 (KnowledgeGraph module): %r" % exc
+            )
+        try:
+            import rdflib  # noqa: F401
+        except Exception as exc:
+            raise RuntimeError("KnowledgeGraphExport requires rdflib (pip install rdflib): %r" % exc)
+
+        per_file: List[Dict[str, Any]] = []
+        kgs: List[Any] = []
+        ttls: List[Tuple[str, str]] = []  # (stem, ttl)
+
+        for ifc_path in self.ifc_files:
+            stem = Path(ifc_path).stem
+            self.log.info("kg_export: building TGraph for %s", stem)
+            g = topograph.build_graph(ifc_path)
+            stamped = self._set_guid_keys(g)
+            kg = KnowledgeGraph.ByTopology(g, includeBOT=self.include_bot, silent=True)
+
+            base_ttl = kg.TurtleString()
+            base_n = self._triple_count(base_ttl)
+            entry: Dict[str, Any] = {
+                "file": Path(ifc_path).name,
+                "vertices": topograph.order(g),
+                "guid_keyed_vertices": stamped,
+                "base_triples": base_n,
+            }
+
+            final_kg = kg
+            ttl = base_ttl
+            if self.reason:
+                final_kg = kg.Infer(profile="rdfs", includeBOT=self.include_bot,
+                                    includeOntologyAxioms=True)
+                ttl = final_kg.TurtleString()
+                inf_n = self._triple_count(ttl)
+                entry["inferred_triples"] = inf_n
+                entry["inferred_delta"] = (None if (inf_n is None or base_n is None)
+                                          else inf_n - base_n)
+
+            entry["prefixes"] = self._prefixes(ttl)
+            per_file.append(entry)
+            kgs.append(final_kg)
+            ttls.append((stem, ttl))
+
+        # Artifact(s): one merged graph, or one per file.
+        merged_triples = None
+        if self.merge and len(kgs) > 1:
+            merged = KnowledgeGraph.MergeGraphs(kgs)
+            mttl = merged.TurtleString()
+            merged_triples = self._triple_count(mttl)
+            name = "merged%s.kg.ttl" % (".reasoned" if self.reason else "")
+            self._artifacts.append((name, mttl, "text/turtle"))
+            if self.materialize and self.reason:
+                self._materialize_edges(mttl, "topologic_reason_rdfs")
+        else:
+            for stem, ttl in ttls:
+                safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", stem) or "model"
+                name = "%s%s.kg.ttl" % (safe, ".reasoned" if self.reason else "")
+                self._artifacts.append((name, ttl, "text/turtle"))
+            if self.materialize and self.reason:
+                for _stem, ttl in ttls:
+                    self._materialize_edges(ttl, "topologic_reason_rdfs")
+
+        self._summary = {
+            "reason": self.reason,
+            "merge": self.merge,
+            "include_bot": self.include_bot,
+            "materialize": self.materialize,
+            "format": self.fmt,
+            "files": per_file,
+            "merged_triples": merged_triples,
+            "artifacts": [a[0] for a in self._artifacts],
+            "materialized_element_edges": len(self._relationships),
+            "duration_ms": int((time.time() - t0) * 1000),
+        }
+
+    def get_artifacts(self) -> List[Tuple[str, Any, str]]:
+        return self._artifacts

--- a/topologicpy-worker/ingest_scripts/WallHosting.py
+++ b/topologicpy-worker/ingest_scripts/WallHosting.py
@@ -1,0 +1,139 @@
+"""Extract door→wall hosting edges (``hosted_by``) — a replayable geometry-derived edge.
+
+A door is hosted in the wall it fills:
+``IfcDoor —IfcRelFillsElement→ IfcOpeningElement —IfcRelVoidsElement→ IfcWall``.
+
+ADR-007 *permanently* excludes those geometry-moving ``IfcRel*`` from the graph-authoring
+registry, so the hosting link is never authored directly. This script recovers it as a
+**replayable ingest recipe** (ADR-006 *"geometry-derived relationships as replayable
+recipes"*): the host wall is read from the explicit IFC relationships — no geometry, no
+heuristics — so re-running reproduces the identical ``hosted_by`` edge set, and the same
+script re-applied to a new revision backfills the edge without touching geometry.
+
+Emits one ``hosted_by`` relationship per hosted door (subject=door, object=wall) in the
+``spatial`` family with ``source_kind=topologic_ingest_WallHosting``. Because the link is
+read straight from ``IfcRelFillsElement``/``IfcRelVoidsElement`` (not inferred), confidence
+is ``1.0``. The emitted set is deterministic: doors are processed in sorted ``GlobalId``
+order and each ``(door, wall)`` pair is emitted at most once.
+
+Downstream, the CDE projection turns ``hosted_by`` into a Neo4j ``HOSTED_BY`` edge
+``(:Element door)-[:HOSTED_BY]->(:Element wall)`` (``_neo4j_rel_label``), which the graph
+door-selector can traverse to match a door by its host wall (``selector.hostWall``).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import List, Optional, Set, Tuple
+
+import ifcopenshell
+
+from ingest_scripts import (
+    Ingester as _Base,
+    Relationship,
+    safe_by_type,
+)
+
+# IfcWall and its standard/elemented-case subtypes carry the void a door fills.
+WALL_TYPES = {"IfcWall", "IfcWallStandardCase", "IfcWallElementedCase"}
+HOSTED_BY_TYPE = "hosted_by"  # IfcDoor --> IfcWall (the wall that hosts the door)
+
+
+def host_wall_global_id(door) -> Optional[str]:
+    """Resolve the GlobalId of the wall a door is hosted in, or ``None``.
+
+    Walks the explicit IFC chain ``door.FillsVoids → IfcOpeningElement →
+    (VoidsElements / HasOpenings) → RelatingBuildingElement`` and accepts only walls.
+    Schema-tolerant on the inverse-attribute names that differ across IFC2X3 / IFC4.
+    """
+    for rel in getattr(door, "FillsVoids", None) or []:
+        opening = getattr(rel, "RelatedOpeningElement", None) or getattr(
+            rel, "RelatingOpeningElement", None
+        )
+        if not opening:
+            continue
+        void_rels = (
+            getattr(opening, "VoidsElements", None)
+            or getattr(opening, "HasOpenings", None)
+            or []
+        )
+        for vrel in void_rels:
+            host = getattr(vrel, "RelatingBuildingElement", None) or getattr(
+                vrel, "RelatedBuildingElement", None
+            )
+            if host and host.is_a() in WALL_TYPES:
+                return host.GlobalId
+    return None
+
+
+class Ingester(_Base):
+    SCRIPT_NAME = "WallHosting"
+    DESCRIPTION = (
+        "Extract door→wall hosting edges (hosted_by) from "
+        "IfcRelFillsElement/IfcRelVoidsElement"
+    )
+
+    def __init__(
+        self,
+        ifc_files: List[Path],
+        log: logging.Logger,
+        door_query: str = "IfcDoor",
+    ):
+        """Extract door→wall hosting relationships from IFC models.
+
+        Reads the explicit IfcRelFillsElement/IfcRelVoidsElement chain that records which
+        wall hosts each door and emits a ``hosted_by`` edge (door → wall). No geometry is
+        computed; the link is deterministic and replayable.
+
+        :param door_query: IFC class queried for hosted elements (default IfcDoor; subtypes included).
+        """
+        super().__init__(ifc_files, log)
+        self.door_query = door_query
+
+    def extract(self) -> None:
+        t0 = time.time()
+        seen: Set[Tuple[str, str]] = set()
+        doors_total = 0
+        hosted = 0
+        unresolved = 0
+
+        for ifc_path in self.ifc_files:
+            self.log.info("wall_hosting: processing %s", ifc_path.name)
+            ifc = ifcopenshell.open(str(ifc_path))
+            doors = safe_by_type(ifc, self.door_query)
+            for door in sorted(doors, key=lambda d: getattr(d, "GlobalId", "") or ""):
+                door_id = getattr(door, "GlobalId", None)
+                if not door_id:
+                    continue
+                doors_total += 1
+                wall_id = host_wall_global_id(door)
+                if not wall_id:
+                    unresolved += 1
+                    continue
+                pair = (door_id, wall_id)
+                if pair in seen:
+                    continue
+                seen.add(pair)
+                self._relationships.append(Relationship(
+                    subject_global_id=door_id,
+                    object_global_id=wall_id,
+                    relationship_family="spatial",
+                    relationship_type=HOSTED_BY_TYPE,
+                    confidence=1.0,
+                    source_kind="topologic_ingest_WallHosting",
+                    evidence={
+                        "rule": "ifc_fills_voids_host_wall",
+                        "doorClass": door.is_a(),
+                        "ifc": ifc_path.name,
+                    },
+                ))
+                hosted += 1
+
+        self._summary = {
+            "doors_total": doors_total,
+            "hosted_doors": hosted,
+            "unresolved_doors": unresolved,
+            "duration_ms": int((time.time() - t0) * 1000),
+        }

--- a/topologicpy-worker/ingest_scripts/WallHosting.py
+++ b/topologicpy-worker/ingest_scripts/WallHosting.py
@@ -41,13 +41,18 @@ WALL_TYPES = {"IfcWall", "IfcWallStandardCase", "IfcWallElementedCase"}
 HOSTED_BY_TYPE = "hosted_by"  # IfcDoor --> IfcWall (the wall that hosts the door)
 
 
-def host_wall_global_id(door) -> Optional[str]:
-    """Resolve the GlobalId of the wall a door is hosted in, or ``None``.
+def host_element_of(door) -> Optional[Tuple[str, str]]:
+    """Resolve ``(globalId, ifcClass)`` of the element whose opening the door fills, or None.
 
     Walks the explicit IFC chain ``door.FillsVoids → IfcOpeningElement →
-    (VoidsElements / HasOpenings) → RelatingBuildingElement`` and accepts only walls.
-    Schema-tolerant on the inverse-attribute names that differ across IFC2X3 / IFC4.
+    (VoidsElements / HasOpenings) → RelatingBuildingElement``. **Prefers a wall** when the
+    opening is voided into one; otherwise returns the actual host (e.g. an ``IfcCovering`` an
+    opening was cut into, a curtain wall, a slab). Every door with an explicit void host
+    therefore resolves — ``WALL_TYPES`` is only a *preference*, not a filter (a too-narrow
+    filter dropped doors hosted in non-wall elements). Schema-tolerant on inverse-attribute
+    names across IFC2X3 / IFC4. Returns None only when the door has no void host at all.
     """
+    fallback: Optional[Tuple[str, str]] = None
     for rel in getattr(door, "FillsVoids", None) or []:
         opening = getattr(rel, "RelatedOpeningElement", None) or getattr(
             rel, "RelatingOpeningElement", None
@@ -63,16 +68,26 @@ def host_wall_global_id(door) -> Optional[str]:
             host = getattr(vrel, "RelatingBuildingElement", None) or getattr(
                 vrel, "RelatedBuildingElement", None
             )
-            if host and host.is_a() in WALL_TYPES:
-                return host.GlobalId
-    return None
+            if not host:
+                continue
+            if host.is_a() in WALL_TYPES:
+                return host.GlobalId, host.is_a()
+            if fallback is None:
+                fallback = (host.GlobalId, host.is_a())
+    return fallback
+
+
+def host_wall_global_id(door) -> Optional[str]:
+    """Backward-compat: the host GlobalId only when it is a wall (else None)."""
+    res = host_element_of(door)
+    return res[0] if res and res[1] in WALL_TYPES else None
 
 
 class Ingester(_Base):
     SCRIPT_NAME = "WallHosting"
     DESCRIPTION = (
-        "Extract door→wall hosting edges (hosted_by) from "
-        "IfcRelFillsElement/IfcRelVoidsElement"
+        "Extract door→host hosting edges (hosted_by, prefers wall) from "
+        "IfcRelFillsElement/IfcRelVoidsElement; host class recorded in evidence"
     )
 
     def __init__(
@@ -97,6 +112,8 @@ class Ingester(_Base):
         seen: Set[Tuple[str, str]] = set()
         doors_total = 0
         hosted = 0
+        hosted_in_wall = 0
+        hosted_in_non_wall = 0
         unresolved = 0
 
         for ifc_path in self.ifc_files:
@@ -108,32 +125,40 @@ class Ingester(_Base):
                 if not door_id:
                     continue
                 doors_total += 1
-                wall_id = host_wall_global_id(door)
-                if not wall_id:
+                res = host_element_of(door)
+                if not res:
                     unresolved += 1
                     continue
-                pair = (door_id, wall_id)
+                host_id, host_class = res
+                pair = (door_id, host_id)
                 if pair in seen:
                     continue
                 seen.add(pair)
+                is_wall = host_class in WALL_TYPES
                 self._relationships.append(Relationship(
                     subject_global_id=door_id,
-                    object_global_id=wall_id,
+                    object_global_id=host_id,
                     relationship_family="spatial",
                     relationship_type=HOSTED_BY_TYPE,
                     confidence=1.0,
                     source_kind="topologic_ingest_WallHosting",
                     evidence={
-                        "rule": "ifc_fills_voids_host_wall",
+                        "rule": "ifc_fills_voids_host",
                         "doorClass": door.is_a(),
+                        "hostClass": host_class,
+                        "isWall": is_wall,
                         "ifc": ifc_path.name,
                     },
                 ))
                 hosted += 1
+                hosted_in_wall += int(is_wall)
+                hosted_in_non_wall += int(not is_wall)
 
         self._summary = {
             "doors_total": doors_total,
             "hosted_doors": hosted,
+            "hosted_in_wall": hosted_in_wall,
+            "hosted_in_non_wall": hosted_in_non_wall,
             "unresolved_doors": unresolved,
             "duration_ms": int((time.time() - t0) * 1000),
         }

--- a/topologicpy-worker/ingest_scripts/ZonePartition.py
+++ b/topologicpy-worker/ingest_scripts/ZonePartition.py
@@ -35,6 +35,7 @@ class Ingester(_Base):
         log: logging.Logger,
         method: str = "community",
         num_partitions: int = 0,
+        max_zone_members: int = 100,
     ):
         """Partition the building graph into zones using community detection.
 
@@ -44,10 +45,15 @@ class Ingester(_Base):
 
         :param method: Partitioning algorithm: community (Louvain), edge_betweenness, or fiedler.
         :param num_partitions: Target number of partitions (0 = auto-detect optimal).
+        :param max_zone_members: Zones with more members than this emit a star to a
+            zone anchor (O(n) relationships) instead of all-pairs (O(n^2)). On the
+            larger TGraph (0.9.50) graphs a single big community could otherwise emit
+            hundreds of thousands of same_zone edges and overwhelm downstream ingest.
         """
         super().__init__(ifc_files, log)
         self.method = method
         self.num_partitions = num_partitions
+        self.max_zone_members = max_zone_members
 
     def extract(self) -> None:
         if not HAS_TOPOLOGICPY:
@@ -100,21 +106,33 @@ class Ingester(_Base):
                 self.log.info("ZonePartition: found %d partitions", total_partitions)
 
                 for zone_id, members in partition_groups.items():
-                    for i, m1 in enumerate(members):
-                        for m2 in members[i + 1:]:
-                            self._relationships.append(Relationship(
-                                subject_global_id=m1,
-                                object_global_id=m2,
-                                relationship_family="grouping",
-                                relationship_type="same_zone",
-                                confidence=0.8,
-                                source_kind="topologic_ingest_ZonePartition",
-                                evidence={
-                                    "zone_id": zone_id,
-                                    "method": self.method,
-                                    "source_file": ifc_path.name,
-                                },
-                            ))
+                    star = len(members) > self.max_zone_members
+                    if star:
+                        # Bound the O(n^2) explosion on large communities: link every
+                        # member to a single stable anchor instead of all-pairs.
+                        anchor = members[0]
+                        pairs = ((anchor, m) for m in members[1:])
+                    else:
+                        pairs = (
+                            (members[i], m2)
+                            for i in range(len(members))
+                            for m2 in members[i + 1:]
+                        )
+                    for m1, m2 in pairs:
+                        self._relationships.append(Relationship(
+                            subject_global_id=m1,
+                            object_global_id=m2,
+                            relationship_family="grouping",
+                            relationship_type="same_zone",
+                            confidence=0.8,
+                            source_kind="topologic_ingest_ZonePartition",
+                            evidence={
+                                "zone_id": zone_id,
+                                "method": self.method,
+                                "zone_topology": "star" if star else "clique",
+                                "source_file": ifc_path.name,
+                            },
+                        ))
 
             except Exception as exc:
                 self.log.error("ZonePartition: failed for %s: %s", ifc_path.name, exc)

--- a/topologicpy-worker/ingest_scripts/__init__.py
+++ b/topologicpy-worker/ingest_scripts/__init__.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -148,6 +148,17 @@ class Ingester(ABC):
             "elements": self.get_elements(),
             "relationships": self.get_relationships(),
         }
+
+    def get_artifacts(self) -> List[Tuple[str, Any, str]]:
+        """Optional non-JSON side artifacts to persist alongside the relationships JSON.
+
+        Returns a list of ``(filename, data, content_type)`` tuples where ``data`` is
+        ``str`` or ``bytes``. Default: none. Scripts that emit a derived artifact —
+        e.g. ``KnowledgeGraphExport`` writing RDF/Turtle — override this. The worker
+        uploads each to ``output/topology/kg/<filename>`` with the same audit lineage
+        as the relationships JSON.
+        """
+        return []
 
 
 @dataclass

--- a/topologicpy-worker/ingest_scripts/routing.py
+++ b/topologicpy-worker/ingest_scripts/routing.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass
 from pathlib import PurePath
 
 ARCHITECTURE_SCRIPTS = ["ExtractSpaces", "SpatialContainment", "SpaceAdjacency", "WallHosting"]
+# Federated cross-discipline geometric relations (penetrates/intersects/sits_in/mounted_on).
+# Run on federated bundles (multiple discipline models in one revision), not single files.
+FEDERATED_SCRIPTS = ["FederatedRelationships"]
 STRUCTURAL_SCRIPTS = ["StructuralConnectivity"]
 MEP_SCRIPTS = ["MepTopology"]
 

--- a/topologicpy-worker/ingest_scripts/routing.py
+++ b/topologicpy-worker/ingest_scripts/routing.py
@@ -11,7 +11,7 @@ import re
 from dataclasses import dataclass
 from pathlib import PurePath
 
-ARCHITECTURE_SCRIPTS = ["ExtractSpaces", "SpatialContainment", "SpaceAdjacency"]
+ARCHITECTURE_SCRIPTS = ["ExtractSpaces", "SpatialContainment", "SpaceAdjacency", "WallHosting"]
 STRUCTURAL_SCRIPTS = ["StructuralConnectivity"]
 MEP_SCRIPTS = ["MepTopology"]
 

--- a/topologicpy-worker/kg_federation_eval/FINDINGS.md
+++ b/topologicpy-worker/kg_federation_eval/FINDINGS.md
@@ -1,0 +1,67 @@
+# KnowledgeGraph federation eval — semantic merge vs geometric federation
+
+TopologicPy **0.9.52**, run in the `ifcpipeline-topologicpy-worker` image
+(`kg_federation_eval/run_eval.py`). Question: when TopologicPy can now convert to RDF,
+does `KnowledgeGraph.MergeGraphs` *connect* models we couldn't connect before — and how
+does it relate to the geometric `FederatedRelationships` ingest (ADR-006)?
+
+## Setup
+
+Three **same-project, same-discipline** electrical models (federated sub-disciplines):
+
+| model | size | TGraph vertices | RDF triples | GlobalId IRIs | build |
+|-------|------|-----------------|-------------|---------------|-------|
+| E1-631-SM-Lightning | 2.3 MB | 5021 | 101 567 | 5014 | 23.8 s |
+| E1-632-SM-Power | 1.9 MB | 3122 | 63 730 | 3115 | 14.2 s |
+| E1-646-SM-Fire_alarm | 1.8 MB | 2946 | 59 663 | 2940 | 13.4 s |
+
+`ifc_guid` keying gives ~100 % GlobalId-unique IRIs (5014/5021 etc.) — the linchpin fix
+works at real scale, not just on the toy model.
+
+## Results
+
+**Semantic merge (`MergeGraphs`):**
+- merged = **162 822** triples; sum of individuals 224 960 → **62 138 deduped** (28 %).
+- **cross-model shared GlobalIds: 2 880** — the same elements re-exported across the
+  three discipline files (shared grid / primary equipment / reference objects — a normal
+  federated-IFC pattern). RDF reconciles them automatically by IRI.
+- element↔element edges in the merged graph: intra-model 13 381, **cross-model ≈ 717**
+  (edges that now span what were separate models, thanks to the shared IRIs).
+
+**Geometric federation (`FederatedRelationships`):** **0** relationships.
+Correct by design — it only emits *cross-discipline* pairs (`classify_pair` returns
+`None` for same-discipline), and all three models are electrical.
+
+## Interpretation — they are complementary, not competing
+
+The naive expectation ("merge just unions models, link discovery stays geometric") is
+**wrong in the shared-identity case.** The two mechanisms cover different federation cases:
+
+| | connects by | needs | finds here |
+|--|-------------|-------|-----------|
+| `MergeGraphs` (semantic) | **shared identity** (GlobalId IRIs) + shared vocabulary | no geometry, any discipline | 2 880 shared elements, ~717 cross-model edges |
+| `FederatedRelationships` (geometric) | **spatial overlap** across disciplines | world coords, distinct identity | 0 (same discipline) |
+
+- Federated discipline models that **re-export shared elements** (very common) → semantic
+  merge reconciles them for free, no geometry. This is real "connect topologies we
+  couldn't before," and it works where geometry finds nothing.
+- Models with **distinct elements that overlap in space across disciplines**
+  (MEP-through-wall) → geometric federation is the only thing that finds those edges; a
+  semantic union won't, because there are no shared IRIs to join on.
+
+**Recommendation:** keep both. Run `FederatedRelationships` for cross-discipline spatial
+edges (ADR-006), and use the `KnowledgeGraph` semantic merge to reconcile shared-identity
+elements across federated files and to expose a unified, SPARQL-queryable multi-model
+graph. Neither is the LPG system of record — both feed it (geometric edges already; the
+semantic cross-model edges via `KnowledgeGraphExport`'s materialize path).
+
+## Caveats
+
+- The 717 cross-model edge count is approximate: each IRI is attributed to a single
+  owning model (last writer wins for shared IRIs), so the exact split of cross- vs
+  intra-model edges around shared elements is fuzzy. The robust, exact metric is the
+  **2 880 shared GlobalIds**.
+- Reasoning (`Infer`) was off for this run — the question was about merge, not inference.
+- A cross-*discipline* run (e.g. architecture + electrical, same project/coords) would
+  show the mirror image: geometric federation finds edges, semantic merge finds few
+  shared IRIs. Worth a follow-up with the `*_2b_BIM_XXX_` A1+E1 pair.

--- a/topologicpy-worker/kg_federation_eval/results/e1_electrical.out.txt
+++ b/topologicpy-worker/kg_federation_eval/results/e1_electrical.out.txt
@@ -1,0 +1,18 @@
+models (3):
+  - E1-631-SM-Lightning.ifc 2.3 MB
+  - E1-632-SM-Power.ifc 1.9 MB
+  - E1-646-SM-Fire_alarm.ifc 1.8 MB
+
+=== SEMANTIC (KnowledgeGraph) ===
+  E1-631-SM-Lightning.ifc            vertices=5021 triples=101567 guid_iris=5014  (23.8s)
+  E1-632-SM-Power.ifc                vertices=3122 triples=63730 guid_iris=3115  (14.2s)
+  E1-646-SM-Fire_alarm.ifc           vertices=2946 triples=59663 guid_iris=2940  (13.4s)
+
+  merged triples: 162822   (sum of individuals: 224960  -> 62138 deduped)
+  cross-model shared GlobalIds: 2880
+  element<->element edges in merged graph: intra-model=13381  cross-model=717
+
+=== GEOMETRIC (FederatedRelationships) ===
+  cross-discipline relationships: 0  by_type={}  (1.9s)
+
+DONE

--- a/topologicpy-worker/kg_federation_eval/run_eval.py
+++ b/topologicpy-worker/kg_federation_eval/run_eval.py
@@ -1,0 +1,137 @@
+"""Semantic federation (KnowledgeGraph.MergeGraphs) vs geometric federation
+(FederatedRelationships) — comparative eval for the LPG-vs-RDF question.
+
+Runs inside the topologicpy-worker image (topologicpy>=0.9.52 + rdflib already
+installed; ingest_scripts on PYTHONPATH=/app). Processes every *.ifc under the
+mount point as ONE federated set and reports:
+
+  semantic merge:  per-model triples, merged triples (+ dedup), cross-model
+                   GlobalId overlap, and cross-model element<->element edges.
+  geometric:       FederatedRelationships cross-discipline edges (by type).
+
+The contrast it establishes: does semantic merge *discover* cross-model links, or
+just union models? (Hypothesis: union + unified query/vocabulary — link discovery
+stays the geometric job.)
+
+Usage:  python run_eval.py /in
+"""
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+logging.basicConfig(level=logging.ERROR)
+log = logging.getLogger("fed_eval")
+
+_GUID_PRED = re.compile(r"(ifc_guid|IFC_global_id|globalId|#guid$)", re.IGNORECASE)
+_NON_EDGE_PRED = re.compile(
+    r"(22-rdf-syntax-ns#type|rdf-schema#|2002/07/owl#|/skos/|/dc/|/dcterms/|vann#|#IFC_)",
+    re.IGNORECASE,
+)
+
+
+def _ttl_iri_guid(ttl):
+    import rdflib
+    rg = rdflib.Graph()
+    rg.parse(data=ttl, format="turtle")
+    m = {}
+    for s, p, o in rg:
+        if _GUID_PRED.search(str(p)) and isinstance(o, rdflib.Literal):
+            m[str(s)] = str(o)
+    return rg, m
+
+
+def main(indir):
+    from ingest_scripts import load_script, topograph
+    from topologicpy.TGraph import TGraph
+    from topologicpy.KnowledgeGraph import KnowledgeGraph
+    import rdflib
+
+    models = sorted(glob.glob(os.path.join(indir, "*.ifc")))
+    print("models (%d):" % len(models))
+    for m in models:
+        print("  -", os.path.basename(m), "%.1f MB" % (os.path.getsize(m) / 1e6))
+
+    kgs = []
+    per_model_guids = {}     # model -> set(guid)
+    iri_owner = {}           # iri -> model (for cross-model edge detection)
+    print("\n=== SEMANTIC (KnowledgeGraph) ===")
+    for m in models:
+        t0 = time.time()
+        g = topograph.build_graph(m)
+        # stamp ifc_guid so IRIs are GlobalId-unique (Ontology._uri_for_topology)
+        for rec in TGraph.Vertices(g):
+            d = rec.get("dictionary") if isinstance(rec, dict) else None
+            if isinstance(d, dict):
+                gid = d.get("IFC_global_id") or d.get("GlobalId")
+                if gid and not d.get("ifc_guid"):
+                    d["ifc_guid"] = gid
+        kg = KnowledgeGraph.ByTopology(g, includeBOT=True, silent=True)
+        ttl = kg.TurtleString()
+        rg, iri_guid = _ttl_iri_guid(ttl)
+        kgs.append(kg)
+        guids = set(iri_guid.values())
+        per_model_guids[m] = guids
+        for iri in iri_guid:
+            iri_owner[iri] = m
+        print("  %-34s vertices=%4d triples=%5d guid_iris=%4d  (%.1fs)" % (
+            os.path.basename(m), topograph.order(g), len(rg), len(guids), time.time() - t0))
+
+    # merge
+    merged = KnowledgeGraph.MergeGraphs(kgs)
+    mttl = merged.TurtleString()
+    mrg = rdflib.Graph(); mrg.parse(data=mttl, format="turtle")
+    sum_individual = sum(len(rdflib.Graph().parse(data=k.TurtleString(), format="turtle"))
+                         for k in kgs)
+    print("\n  merged triples: %d   (sum of individuals: %d  -> %d deduped)" % (
+        len(mrg), sum_individual, sum_individual - len(mrg)))
+
+    # cross-model GlobalId overlap
+    all_guids = [g for s in per_model_guids.values() for g in s]
+    shared = set()
+    seen = set()
+    for g in all_guids:
+        if g in seen:
+            shared.add(g)
+        seen.add(g)
+    print("  cross-model shared GlobalIds: %d" % len(shared))
+
+    # cross-model element<->element edges in the merged graph
+    cross = 0
+    intra = 0
+    for s, p, o in mrg:
+        ps = str(p)
+        if _NON_EDGE_PRED.search(ps) or _GUID_PRED.search(ps):
+            continue
+        so, oo = iri_owner.get(str(s)), iri_owner.get(str(o))
+        if so and oo:
+            if so != oo:
+                cross += 1
+            else:
+                intra += 1
+    print("  element<->element edges in merged graph: intra-model=%d  cross-model=%d" % (intra, cross))
+
+    # geometric federation on the same set
+    print("\n=== GEOMETRIC (FederatedRelationships) ===")
+    t0 = time.time()
+    try:
+        Fed = load_script("FederatedRelationships")
+        fi = Fed(ifc_files=[Path(m) for m in models], log=log)
+        fi.extract()
+        fs = fi.get_summary()
+        print("  cross-discipline relationships: %d  by_type=%s  (%.1fs)" % (
+            fs.get("relationships", 0), fs.get("by_type", {}), time.time() - t0))
+    except Exception as e:
+        print("  FederatedRelationships failed:", repr(e))
+
+    print("\nDONE")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1] if len(sys.argv) > 1 else "/in")

--- a/topologicpy-worker/requirements.txt
+++ b/topologicpy-worker/requirements.txt
@@ -5,10 +5,15 @@ ifcopenshell==0.8.4
 # verified during this worker spike.
 # NOTE (eval/tgraph-0.9.50 branch): bumped to >=0.9.50 to bring in the new
 # Python-native TGraph data structure. See topologicpy-worker/tgraph_eval/.
-topologicpy>=0.9.50
+# NOTE (0.9.52): adds the KnowledgeGraph module (RDF/Turtle export, RDFS+BOT
+# reasoning, MergeGraphs federation) used by ingest_scripts/KnowledgeGraphExport.
+topologicpy>=0.9.52
 # Required by ingest_scripts/topograph.community() -> TGraph.CommunityPartition
 # (algorithm="louvain"), used by ZonePartition. topologicpy does not pull it in.
 python-igraph>=0.11
+# Optional dep enabled for KnowledgeGraphExport: rdflib is the RDF engine behind
+# KnowledgeGraph (TurtleString/Infer/Query). topologicpy does not pull it in.
+rdflib>=7,<8
 tqdm>=4.68.1
 
 # Queue and data validation

--- a/topologicpy-worker/tasks.py
+++ b/topologicpy-worker/tasks.py
@@ -2877,6 +2877,59 @@ def _run_ingest_core(job_data: dict) -> dict:
             result["storage"] = "filesystem"
             result["output_path"] = out_path
 
+        # Optional side artifacts (e.g. RDF/Turtle from KnowledgeGraphExport).
+        # Additive: scripts that don't override get_artifacts() return [] and skip this.
+        try:
+            artifacts = ingester.get_artifacts() or []
+        except Exception:
+            logger.warning("ingest: get_artifacts() failed for %s", script_name, exc_info=True)
+            artifacts = []
+        if artifacts:
+            result_artifacts: List[dict] = []
+            for art in artifacts:
+                try:
+                    art_name, art_data, art_ctype = art
+                except (ValueError, TypeError):
+                    logger.warning("ingest: malformed artifact from %s: %r", script_name, art)
+                    continue
+                art_bytes = art_data.encode("utf-8") if isinstance(art_data, str) else art_data
+                if s3.is_enabled():
+                    art_key = f"output/topology/kg/{art_name}"
+                    art_local = os.path.join(tmpdir, art_name)
+                    with open(art_local, "wb") as f:
+                        f.write(art_bytes)
+                    try:
+                        art_audit = s3.upload_and_audit(
+                            art_local,
+                            key=art_key,
+                            operation=f"topologicpy_ingest_{script_name}_artifact",
+                            worker=WORKER_NAME,
+                            job_id=_current_job_id(),
+                            parents=[("input", key) for key in parent_keys],
+                        )
+                        result_artifacts.append({
+                            "key": art_key,
+                            "path": f"s3://{s3.bucket_name()}/{art_key}",
+                            "content_type": art_ctype,
+                            "bytes": len(art_bytes),
+                            "audit_id": art_audit.get("audit_id"),
+                            "sha256": art_audit.get("sha256"),
+                            "version_id": art_audit.get("version_id"),
+                        })
+                    except Exception as art_exc:
+                        logger.warning("ingest: artifact upload failed for %s: %s", art_name, art_exc)
+                else:
+                    art_dir = os.path.join(OUTPUT_DIR, "topology", "kg")
+                    os.makedirs(art_dir, exist_ok=True)
+                    art_path = os.path.join(art_dir, art_name)
+                    with open(art_path, "wb") as f:
+                        f.write(art_bytes)
+                    result_artifacts.append({
+                        "path": art_path, "content_type": art_ctype, "bytes": len(art_bytes),
+                    })
+            if result_artifacts:
+                result["artifacts"] = result_artifacts
+
         result["relationships"] = output_data["relationships"]
         result["elements"] = output_data["elements"]
 


### PR DESCRIPTION
Lands the TopologicPy **TGraph migration** and the new **0.9.52 KnowledgeGraph** capability on main (main was on `topologicpy>=0.9.43`).

## TGraph adoption (eval-driven)
- Python-native TGraph adapter (`ingest_scripts/topograph.py`) replacing legacy `Graph`; all ingest scripts migrated.
- Eval suite (`tgraph_eval/`) concluded adopt TGraph (15–29× faster construction, less RAM, never drops data; recursion guard for Bridges/CutVertices).
- New geometry-derived recipes: `WallHosting` (door→wall `hosted_by`) and `FederatedRelationships` (cross-discipline edges, iterator-accelerated 27min→37s).

## TopologicPy 0.9.52 — RDF as a derived projection
- Bump `topologicpy>=0.9.52` + `rdflib`.
- Opt-in `KnowledgeGraphExport`: TGraph → RDF/Turtle (BOT/Brick/IFC-OWL/GeoSPARQL/PROV), optional RDFS+BOT reasoning (`Infer`), multi-model `MergeGraphs`.
- `Ingester.get_artifacts()` hook + artifact upload to `output/topology/kg/` (additive; existing scripts unaffected).
- GlobalId IRI fix (`ifc_guid` stamping); reasoning materializes inferred element↔element edges into the LPG (`source_kind=topologic_reason_rdfs`, `assumed`).
- `kg_federation_eval/FINDINGS.md`: semantic merge vs geometric federation are complementary.

LPG/Neo4j remains the system of record; RDF is a derived projection (cde ADR-015).

## Verification
- Worker rebuilt at 0.9.52; KnowledgeGraphExport verified end-to-end (RDF export, +1090 inferred triples, 141 materialized edges, merge); `SpaceAdjacency` regression-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)