### PR TITLE
fix(topologicpy): 0.9.58 parity — KG export guid/pset predicates, pin bump

### DIFF
--- a/topologicpy-worker/ingest_scripts/KnowledgeGraphExport.py
+++ b/topologicpy-worker/ingest_scripts/KnowledgeGraphExport.py
@@ -38,11 +38,15 @@ from ingest_scripts import Ingester as _Base, Relationship
 from ingest_scripts import topograph
 
 # Predicates that are schema/annotation, never instance-to-instance edges.
+# The trailing alternatives cover topologicpy >=0.9.58, which links property
+# sets and type objects as IRI resources (rooted, so they carry GUIDs and pass
+# the element-endpoint filter) instead of the <=0.9.57 top:IFC_* literals.
 _NON_EDGE_PRED = re.compile(
-    r"(22-rdf-syntax-ns#type|rdf-schema#|2002/07/owl#|/skos/|/dc/|/dcterms/|vann#|#IFC_)",
+    r"(22-rdf-syntax-ns#type|rdf-schema#|2002/07/owl#|/skos/|/dc/|/dcterms/|vann#|#IFC_"
+    r"|hasPropertySet$|isPropertySetOf$|hasIFCType$|isIFCTypeOf$)",
     re.IGNORECASE,
 )
-_GUID_PRED = re.compile(r"(ifc_guid|IFC_global_id|globalId|#guid$)", re.IGNORECASE)
+_GUID_PRED = re.compile(r"(ifc_guid|ifcGUID|ifcGlobalId|IFC_global_id|globalId|#guid$)", re.IGNORECASE)
 
 
 def _localname(uri: str) -> str:

--- a/topologicpy-worker/requirements.txt
+++ b/topologicpy-worker/requirements.txt
@@ -7,10 +7,15 @@ ifcopenshell==0.8.4
 # Python-native TGraph data structure. See topologicpy-worker/tgraph_eval/.
 # NOTE (0.9.52): adds the KnowledgeGraph module (RDF/Turtle export, RDFS+BOT
 # reasoning, MergeGraphs federation) used by ingest_scripts/KnowledgeGraphExport.
+# NOTE (0.9.58): LPG surface verified identical to 0.9.57 (ByIFCFile shape,
+# snake_case relationship values, ToPython/FromPython round-trip). RDF/TTL
+# vocabulary is NOT stable across 0.9.57->0.9.58 (top:IFC_* removed; bot:/dict:
+# namespaces added; guid literal predicate is now top:ifcGUID — _GUID_PRED in
+# KnowledgeGraphExport matches both old and new).
 # Upper-bounded: KnowledgeGraphExport memoizes KnowledgeGraph internals and the
 # topograph disk cache round-trips TGraph.ToPython/FromPython — re-verify both
 # (ingest_bench fingerprints) before crossing 0.10.
-topologicpy>=0.9.52,<0.10
+topologicpy>=0.9.58,<0.10
 # Required by ingest_scripts/topograph.community() -> TGraph.CommunityPartition
 # (algorithm="louvain"), used by ZonePartition. topologicpy does not pull it in.
 python-igraph>=0.11


### PR DESCRIPTION
## Summary
- topologicpy 0.9.57 → 0.9.58 parity (topologic_core unchanged at 8.0.4). LPG surface verified byte-identical; the RDF/TTL vocabulary overhaul upstream broke `KnowledgeGraphExport` edge materialization.
- `_GUID_PRED` now matches the new `top:ifcGUID` guid predicate (was `top:ifcGlobalId`) — without it, `materialized_element_edges` silently drops to **0**. Verified 0 → 67,777 on the duplex fixture pair.
- `_NON_EDGE_PRED` excludes the new pset/type resource links (`hasPropertySet`/`isPropertySetOf`/`hasIFCType`/`isIFCTypeOf`), which are rooted (GUID-carrying) in 0.9.58 and would leak ~26k non-element rows past the element→element filter. Final: 41,539 edges, all semantic element families (incl. new `adjacentElement`, `feeds`, `fillsOpening`, inverses).
- Pin bumped to `topologicpy>=0.9.58,<0.10` with audit notes.

## Verification
- Full 9-agent upgrade audit + live checks inside the worker image (0.9.57 vs 0.9.58 overlays).
- `ingest_bench`: **19/19 cases fingerprint-identical** (`rel_sha256`/`elem_sha256`) vs the `final-*` references.
- Deployed: primary `topologicpy-worker` + `api-gateway` rebuilt, w1 fleet synced to the same image; live API smoke (SpatialContainment on A1 → 1,721 rels) green through the RQ path on 0.9.58.
- Rollback image tagged `ifcpipeline-topologicpy-worker:0.9.57-rollback` on the primary.

## Notes for downstream
- RDF/TTL consumers must re-baseline (predicate families renamed; `dict:`/`bot:`/`ifc:` namespaces added).
- The materialized `topologic_reason_rdfs` row set is not a superset — CDE re-imports into an existing revision leave stale assumed rows (follow-up task spawned on the CDE side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)