### PR TITLE
Port RevitWorkerApp 1.4.5 from Forgejo

### DIFF
--- a/api-gateway/api-gateway.py
+++ b/api-gateway/api-gateway.py
@@ -2039,7 +2039,7 @@ async def upload_revit_log(
 
     Args:
         job_id (str): The job ID to associate with the log file.
-        log_type (str): The type of log (journal, pyrevit, rtv, worker, ddc).
+        log_type (str): The type of log (journal, pyrevit, rtv, worker).
         file (UploadFile): The log file to upload.
 
     Returns:

--- a/api-gateway/api-gateway.py
+++ b/api-gateway/api-gateway.py
@@ -1975,6 +1975,23 @@ async def list_patch_recipes(
         logger.error(f"Error listing recipes: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=str(e))
 
+def _revit_job_meta(request: RevitExecuteRequest) -> dict:
+    """RQ ``meta`` for job_history / dashboard: always set model_name + commandtype when possible.
+
+    Callers (n8n) often send only ``model_path``; Postgres sync reads ``meta`` fields.
+    """
+    rq_meta = dict(request.meta or {})
+    mp = (request.model_path or "").strip()
+    if mp:
+        base = os.path.basename(mp.replace("\\", "/"))
+        if base:
+            rq_meta.setdefault("model_name", base)
+            rq_meta.setdefault("model_path", mp)
+    ct = request.command_type.value if hasattr(request.command_type, "value") else str(request.command_type)
+    rq_meta.setdefault("commandtype", ct)
+    return rq_meta
+
+
 @app.post("/revit/execute", tags=["Revit"])
 async def execute_revit_command(request: RevitExecuteRequest, _: str = Depends(verify_access)):
     """
@@ -1992,14 +2009,19 @@ async def execute_revit_command(request: RevitExecuteRequest, _: str = Depends(v
     try:
         job_timeout = f"{request.timeout_seconds + 300}s"
         job_data = json.loads(request.json())
+        rq_meta = _revit_job_meta(request)
         job = revit_queue.enqueue(
             "tasks.run_revit_command",
             job_data,
             job_timeout=job_timeout,
             result_ttl=JOB_RESULT_TTL,
+            meta=rq_meta,
         )
 
-        logger.info(f"Enqueued revit job with ID: {job.id} (type={request.command_type}, script={request.script_path})")
+        logger.info(
+            f"Enqueued revit job with ID: {job.id} (type={request.command_type}, "
+            f"script={request.script_path}, model_path={request.model_path})"
+        )
         return {"job_id": job.id}
     except Exception as e:
         logger.error(f"Error enqueueing revit job: {str(e)}")
@@ -2017,7 +2039,7 @@ async def upload_revit_log(
 
     Args:
         job_id (str): The job ID to associate with the log file.
-        log_type (str): The type of log (journal, pyrevit, rtv, worker).
+        log_type (str): The type of log (journal, pyrevit, rtv, worker, ddc).
         file (UploadFile): The log file to upload.
 
     Returns:

--- a/revit-worker/README.md
+++ b/revit-worker/README.md
@@ -155,7 +155,6 @@ cp revit-worker/RevitWorkerApp.exe /home/jonatan/INTERAXO/RevitWorkerApp.exe
 | `pyrevit` | Runs `pyrevit run <script_path> [model_path] [--revit=YYYY] [arguments...]` |
 | `rtv` | Runs `powershell -ExecutionPolicy Bypass -NonInteractive -File <script_path> [-BatchFile ...] [-JobId ...] [arguments...]` |
 | `powershell` | Runs `powershell -ExecutionPolicy Bypass -NonInteractive -File <script_path> [-ModelPath ...] [-RevitVersion ...] [arguments...]` |
-| `ddc` | Runs **DDC** RVT→IFC converter (standalone, no Revit). Exe path: `script_path`, or env `DDC_EXPORTER_PATH`, or first existing of `B:\INTERAXO\DDC\DDC_REVIT2IFC_CONVERTER\RVT2IFCconverter.exe`, `C:\DDC\RvtExporter.exe`. **Requires** `model_path`. Optional `output_dir` (otherwise writes `.ifc` next to the `.rvt`). |
 
 The `-JobId` parameter on RTV jobs ensures unique schedule XML filenames when multiple jobs run concurrently.
 
@@ -174,14 +173,13 @@ Request body (`RevitExecuteRequest`):
 
 ```json
 {
-  "command_type": "pyrevit | rtv | powershell | ddc",
+  "command_type": "pyrevit | rtv | powershell",
   "script_path": "C:\\Scripts\\my_script.py",
   "model_path": "C:\\Models\\project.rvt",
   "revit_version": "2025",
   "batch_file": "C:\\Batches\\export.rbxml",
   "arguments": [],
   "timeout_seconds": 3600,
-  "output_dir": "C:\\Output\\ifc",
   "working_directory": "C:\\Output",
   "meta": { "project": "Example", "model_name": "project.rvt" }
 }
@@ -189,14 +187,13 @@ Request body (`RevitExecuteRequest`):
 
 | Field | Required | Used by | Description |
 |-------|----------|---------|-------------|
-| `command_type` | Yes | all | `pyrevit`, `rtv`, `powershell`, or `ddc` |
-| `script_path` | Yes except `ddc` | all | Path to script on the Windows machine. Optional for `ddc` (falls back to `DDC_EXPORTER_PATH` or default installer paths). |
-| `model_path` | Required for `ddc` | pyrevit, ddc | `.rvt` model file |
+| `command_type` | Yes | all | `pyrevit`, `rtv`, or `powershell` |
+| `script_path` | Yes | all | Path to script on the Windows machine |
+| `model_path` | No | pyrevit | `.rvt` model file |
 | `revit_version` | No | pyrevit | e.g. `"2025"` → `--revit=2025` |
 | `batch_file` | No | rtv | `.rbxml` batch file → `-BatchFile` arg |
 | `arguments` | No | all | Additional CLI arguments |
 | `timeout_seconds` | No | all | Max execution time (default 3600, range 10–86400) |
-| `output_dir` | No | ddc | Directory for the exported `.ifc` (default: next to the `.rvt`) |
 | `working_directory` | No | all | Working directory for the subprocess |
 | `meta` | No | all | Arbitrary metadata stored in RQ job meta (visible in dashboard) |
 

--- a/revit-worker/README.md
+++ b/revit-worker/README.md
@@ -112,7 +112,8 @@ The app starts with the settings window visible on first launch. All settings ar
 
 ### Docker cross-compile (recommended)
 
-Build from Linux using the .NET 8 SDK Docker image — avoids local SDK version issues:
+Build from Linux using the .NET 8 SDK Docker image — avoids local SDK version issues.
+The published exe is **v1.4.5** (`<Version>` in `RevitWorkerApp.csproj`; shown in the window title, tray tooltip, and Redis worker hash).
 
 ```bash
 cd revit-worker
@@ -154,6 +155,7 @@ cp revit-worker/RevitWorkerApp.exe /home/jonatan/INTERAXO/RevitWorkerApp.exe
 | `pyrevit` | Runs `pyrevit run <script_path> [model_path] [--revit=YYYY] [arguments...]` |
 | `rtv` | Runs `powershell -ExecutionPolicy Bypass -NonInteractive -File <script_path> [-BatchFile ...] [-JobId ...] [arguments...]` |
 | `powershell` | Runs `powershell -ExecutionPolicy Bypass -NonInteractive -File <script_path> [-ModelPath ...] [-RevitVersion ...] [arguments...]` |
+| `ddc` | Runs **DDC** RVT→IFC converter (standalone, no Revit). Exe path: `script_path`, or env `DDC_EXPORTER_PATH`, or first existing of `B:\INTERAXO\DDC\DDC_REVIT2IFC_CONVERTER\RVT2IFCconverter.exe`, `C:\DDC\RvtExporter.exe`. **Requires** `model_path`. Optional `output_dir` (otherwise writes `.ifc` next to the `.rvt`). |
 
 The `-JobId` parameter on RTV jobs ensures unique schedule XML filenames when multiple jobs run concurrently.
 
@@ -172,13 +174,14 @@ Request body (`RevitExecuteRequest`):
 
 ```json
 {
-  "command_type": "pyrevit | rtv | powershell",
+  "command_type": "pyrevit | rtv | powershell | ddc",
   "script_path": "C:\\Scripts\\my_script.py",
   "model_path": "C:\\Models\\project.rvt",
   "revit_version": "2025",
   "batch_file": "C:\\Batches\\export.rbxml",
   "arguments": [],
   "timeout_seconds": 3600,
+  "output_dir": "C:\\Output\\ifc",
   "working_directory": "C:\\Output",
   "meta": { "project": "Example", "model_name": "project.rvt" }
 }
@@ -186,13 +189,14 @@ Request body (`RevitExecuteRequest`):
 
 | Field | Required | Used by | Description |
 |-------|----------|---------|-------------|
-| `command_type` | Yes | all | `pyrevit`, `rtv`, or `powershell` |
-| `script_path` | Yes | all | Path to script on the Windows machine |
-| `model_path` | No | pyrevit | `.rvt` model file |
+| `command_type` | Yes | all | `pyrevit`, `rtv`, `powershell`, or `ddc` |
+| `script_path` | Yes except `ddc` | all | Path to script on the Windows machine. Optional for `ddc` (falls back to `DDC_EXPORTER_PATH` or default installer paths). |
+| `model_path` | Required for `ddc` | pyrevit, ddc | `.rvt` model file |
 | `revit_version` | No | pyrevit | e.g. `"2025"` → `--revit=2025` |
 | `batch_file` | No | rtv | `.rbxml` batch file → `-BatchFile` arg |
 | `arguments` | No | all | Additional CLI arguments |
 | `timeout_seconds` | No | all | Max execution time (default 3600, range 10–86400) |
+| `output_dir` | No | ddc | Directory for the exported `.ifc` (default: next to the `.rvt`) |
 | `working_directory` | No | all | Working directory for the subprocess |
 | `meta` | No | all | Arbitrary metadata stored in RQ job meta (visible in dashboard) |
 

--- a/revit-worker/app/AppLog.cs
+++ b/revit-worker/app/AppLog.cs
@@ -75,11 +75,41 @@ public static class AppLog
             {
                 var dir = Path.GetDirectoryName(path)!;
                 if (!Directory.Exists(dir)) Directory.CreateDirectory(dir);
+
+                // Seed buffer from the tail of the previous log session
+                if (File.Exists(path))
+                    SeedFromExistingLog(path);
+
                 File.AppendAllText(path, $"--- Log started {DateTime.UtcNow:yyyy-MM-dd HH:mm:ss} UTC ---{Environment.NewLine}");
                 return path;
             }
             catch { }
         }
         return null;
+    }
+
+    /// <summary>
+    /// Reads the last ~200 lines of the existing log file into the buffer so the UI
+    /// shows previous session context immediately after a redeploy.
+    /// </summary>
+    private static void SeedFromExistingLog(string path, int tailLines = 200)
+    {
+        try
+        {
+            var allLines = File.ReadAllLines(path);
+            var tail = allLines.Length > tailLines
+                ? allLines[^tailLines..]
+                : allLines;
+
+            lock (Lock)
+            {
+                foreach (var line in tail)
+                    Buffer.Add(line);
+                // Trim to max if we somehow exceed it
+                while (Buffer.Count > 2000)
+                    Buffer.RemoveAt(0);
+            }
+        }
+        catch { }
     }
 }

--- a/revit-worker/app/AppSettings.cs
+++ b/revit-worker/app/AppSettings.cs
@@ -47,13 +47,21 @@ public sealed class AppSettings
         try
         {
             var json = File.ReadAllText(path);
-            var settings = JsonSerializer.Deserialize<AppSettings>(json);
-            return settings ?? new AppSettings();
+            var settings = JsonSerializer.Deserialize<AppSettings>(json) ?? new AppSettings();
+            settings.BackfillDefaults();
+            return settings;
         }
         catch
         {
             return new AppSettings();
         }
+    }
+
+    private void BackfillDefaults()
+    {
+        if (string.IsNullOrWhiteSpace(RedisUrl)) RedisUrl = DefaultRedisUrl;
+        if (string.IsNullOrWhiteSpace(QueueNames)) QueueNames = DefaultQueueNames;
+        if (WorkerCount < MinWorkerCount) WorkerCount = DefaultWorkerCount;
     }
 
     public void Save()
@@ -63,5 +71,6 @@ public sealed class AppSettings
         File.WriteAllText(path, json);
     }
 
+    [JsonIgnore]
     public int ClampedWorkerCount => Math.Clamp(WorkerCount, MinWorkerCount, MaxWorkerCount);
 }

--- a/revit-worker/app/MainForm.cs
+++ b/revit-worker/app/MainForm.cs
@@ -1,4 +1,6 @@
 using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Text.RegularExpressions;
 using System.Windows.Forms;
 
 namespace RevitWorkerApp;
@@ -6,391 +8,617 @@ namespace RevitWorkerApp;
 public sealed class MainForm : Form
 {
     private readonly TrayApplicationContext _trayContext;
+
     private TextBox _txtRedisUrl = null!;
     private TextBox _txtApiGatewayUrl = null!;
     private TextBox _txtApiKey = null!;
     private Button _btnConnect = null!;
-    private Button _btnAddWorker = null!;
-    private ListView _listWorkers = null!;
-    private ListView _listQueues = null!;
     private Label _lblStatus = null!;
+    private Button _btnAddWorker = null!;
+    private Button _btnToggleLog = null!;
+    private FlowLayoutPanel _workerGrid = null!;
+    private SplitContainer _splitMain = null!;
     private TextBox _txtLog = null!;
+    private Label _lblLogTitle = null!;
+    private Label? _btnClearFilter;
+    private Label? _btnWrapToggle;
+    private QueueStatsBar _queueStats = null!;
+
     private AppSettings _settings = null!;
     private System.Windows.Forms.Timer? _statsTimer;
+    private System.Windows.Forms.Timer? _durationTimer;
+    private string? _selectedWorker;
+    private readonly List<string> _allLogLines = new();
+    private readonly Dictionary<string, WorkerCard> _workerCards = new();
+    private readonly Dictionary<string, AdoptedJobCard> _adoptedCards = new();
+    private bool _logVisible = true;
+    private bool _initialized;
 
+    private static readonly Font SectionFont = new("Segoe UI", 8f, FontStyle.Bold);
     private static readonly Font UIFont = new("Segoe UI", 9f);
     private static readonly Font UIFontSmall = new("Segoe UI", 8f);
-    private static readonly Color AccentGreen = Color.FromArgb(0x22, 0xc5, 0x5e);
-    private static readonly Color AccentRed = Color.FromArgb(0xef, 0x44, 0x44);
-    private static readonly Color BgColor = Color.FromArgb(0xfa, 0xfa, 0xfa);
-    private static readonly Color PanelBg = Color.White;
-    private static readonly Color ButtonBlue = Color.FromArgb(0x22, 0x8b, 0xe6);
+    private static readonly Font LogFont = new("Consolas", 8f);
 
-    private const int Pad = 10;
-    private const int InnerWidth = 310;
+    private static readonly Color AccentGreen = Color.FromArgb(0x16, 0xA3, 0x4A);
+    private static readonly Color AccentOrange = Color.FromArgb(0xEA, 0x88, 0x0F);
+    private static readonly Color AccentAmber = Color.FromArgb(0xD9, 0x77, 0x06);
+    private static readonly Color AccentRed = Color.FromArgb(0xDC, 0x26, 0x26);
+    private static readonly Color AccentBlue = Color.FromArgb(0x25, 0x63, 0xEB);
+    private static readonly Color BgColor = Color.FromArgb(0xF1, 0xF5, 0xF9);
+    private static readonly Color CardBorder = Color.FromArgb(0xE2, 0xE8, 0xF0);
+    private static readonly Color SelectedBorder = Color.FromArgb(0x25, 0x63, 0xEB);
+    private static readonly Color SectionLabelColor = Color.FromArgb(0x64, 0x74, 0x8B);
+    private static readonly Color LogBg = Color.FromArgb(0x0F, 0x17, 0x2A);
+    private static readonly Color LogFg = Color.FromArgb(0xCB, 0xD5, 0xE1);
+    private static readonly Color Muted = Color.FromArgb(0x94, 0xA3, 0xB8);
+
+    private const int Pad = 14;
 
     public MainForm(TrayApplicationContext trayContext)
     {
         _trayContext = trayContext;
-        _trayContext.SetMainForm(this);
+        SuspendLayout();
         BuildForm();
+        ResumeLayout(true);
+        _initialized = true;
+        _trayContext.SetMainForm(this);
         LoadSettings();
         SubscribeToEvents();
+        StartDurationTimer();
     }
+
+    // ──────────────────────────────────────────────
+    //  Form construction
+    // ──────────────────────────────────────────────
 
     private void BuildForm()
     {
-        Text = "Revit Worker";
+        Text = $"Revit Worker v{Program.Version}";
         FormBorderStyle = FormBorderStyle.Sizable;
-        MaximizeBox = false;
-        MinimizeBox = true;
-        ShowInTaskbar = true;
         BackColor = BgColor;
         Font = UIFont;
         StartPosition = FormStartPosition.CenterScreen;
-        MinimumSize = new Size(350, 570);
-        ClientSize = new Size(InnerWidth + 2 * Pad, 670);
+        MinimumSize = new Size(600, 480);
+        ClientSize = new Size(980, 640);
+        SetStyle(ControlStyles.OptimizedDoubleBuffer | ControlStyles.AllPaintingInWmPaint, true);
 
-        var y = Pad;
+        BuildMainArea();
+        BuildWorkerHeader();
+        BuildConfigSection();
+    }
 
-        // --- Connection ---
+    private void BuildConfigSection()
+    {
+        var formW = ClientSize.Width;
+
+        var outer = new Panel
+        {
+            Dock = DockStyle.Top,
+            BackColor = BgColor,
+            Padding = new Padding(Pad, Pad / 2, Pad, 4),
+            Width = formW,
+        };
+
+        var cardW = formW - 2 * Pad;
+        var card = new Panel
+        {
+            Dock = DockStyle.Fill,
+            BackColor = Color.White,
+            Width = cardW,
+        };
+        card.Paint += (_, pe) =>
+        {
+            using var pen = new Pen(CardBorder);
+            pe.Graphics.DrawRectangle(pen, 0, 0, card.Width - 1, card.Height - 1);
+        };
+
+        var cw = cardW - 2;
+        var y = 14;
+
         var lblConn = new Label
         {
             Text = "CONNECTION",
-            Font = UIFontSmall,
-            ForeColor = Color.Gray,
-            Location = new Point(Pad, y),
-            AutoSize = true
+            Font = SectionFont,
+            ForeColor = SectionLabelColor,
+            Location = new Point(14, y),
+            AutoSize = true,
         };
-        Controls.Add(lblConn);
-        y += 18;
-
-        var connPanel = new Panel
-        {
-            Location = new Point(Pad, y),
-            Size = new Size(InnerWidth, 36),
-            BackColor = PanelBg,
-            BorderStyle = BorderStyle.FixedSingle,
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
-        };
-        Controls.Add(connPanel);
-
-        _txtRedisUrl = new TextBox
-        {
-            Location = new Point(6, 6),
-            Size = new Size(InnerWidth - 82, 22),
-            BorderStyle = BorderStyle.None,
-            Font = UIFont,
-            PlaceholderText = "redis://host:6379/0",
-            BackColor = PanelBg,
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
-        };
-        connPanel.Controls.Add(_txtRedisUrl);
+        card.Controls.Add(lblConn);
+        y += 20;
 
         _btnConnect = new Button
         {
             Text = "Connect",
-            Size = new Size(70, 32),
+            Size = new Size(88, 26),
             FlatStyle = FlatStyle.Flat,
-            BackColor = ButtonBlue,
+            BackColor = AccentBlue,
             ForeColor = Color.White,
             Font = UIFontSmall,
             Cursor = Cursors.Hand,
-            Anchor = AnchorStyles.Top | AnchorStyles.Right
+            Anchor = AnchorStyles.Top | AnchorStyles.Right,
         };
-        _btnConnect.Location = new Point(connPanel.Width - _btnConnect.Width - 2, 1);
         _btnConnect.FlatAppearance.BorderSize = 0;
+        _btnConnect.Location = new Point(cw - _btnConnect.Width - 12, y);
         _btnConnect.Click += BtnConnect_Click;
-        connPanel.Controls.Add(_btnConnect);
+        card.Controls.Add(_btnConnect);
 
-        y += 44;
+        _txtRedisUrl = new TextBox
+        {
+            Location = new Point(14, y + 1),
+            Size = new Size(cw - 14 - _btnConnect.Width - 22, 24),
+            Font = UIFontSmall,
+            PlaceholderText = "redis://host:6379/0",
+            BorderStyle = BorderStyle.FixedSingle,
+            BackColor = Color.White,
+            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
+        };
+        card.Controls.Add(_txtRedisUrl);
+        y += 32;
 
         _lblStatus = new Label
         {
             Text = "\u25cf Disconnected",
             Font = UIFontSmall,
             ForeColor = AccentRed,
-            Location = new Point(Pad, y),
-            AutoSize = true
+            Location = new Point(14, y),
+            AutoSize = true,
         };
-        Controls.Add(_lblStatus);
+        card.Controls.Add(_lblStatus);
         y += 22;
 
-        // --- API Gateway (optional, for log uploads) ---
+        card.Controls.Add(MakeDivider(14, y, cw - 28));
+        y += 10;
+
         var lblApi = new Label
         {
-            Text = "API GATEWAY (optional — for log uploads)",
-            Font = UIFontSmall,
-            ForeColor = Color.Gray,
-            Location = new Point(Pad, y),
-            AutoSize = true
+            Text = "API GATEWAY",
+            Font = SectionFont,
+            ForeColor = SectionLabelColor,
+            Location = new Point(14, y),
+            AutoSize = true,
         };
-        Controls.Add(lblApi);
-        y += 18;
-
-        var apiPanel = new Panel
-        {
-            Location = new Point(Pad, y),
-            Size = new Size(InnerWidth, 62),
-            BackColor = PanelBg,
-            BorderStyle = BorderStyle.FixedSingle,
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
-        };
-        Controls.Add(apiPanel);
+        card.Controls.Add(lblApi);
+        y += 20;
 
         _txtApiGatewayUrl = new TextBox
         {
-            Location = new Point(6, 4),
-            Size = new Size(InnerWidth - 14, 22),
-            BorderStyle = BorderStyle.None,
-            Font = UIFont,
-            PlaceholderText = "http://bim-host-ubnt:8000",
-            BackColor = PanelBg,
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
+            Location = new Point(14, y),
+            Size = new Size((cw - 38) / 2, 24),
+            Font = UIFontSmall,
+            PlaceholderText = "http://host:8000",
+            BorderStyle = BorderStyle.FixedSingle,
+            BackColor = Color.White,
+            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
         };
-        apiPanel.Controls.Add(_txtApiGatewayUrl);
+        card.Controls.Add(_txtApiGatewayUrl);
 
         _txtApiKey = new TextBox
         {
-            Location = new Point(6, 32),
-            Size = new Size(InnerWidth - 14, 22),
-            BorderStyle = BorderStyle.None,
-            Font = UIFont,
+            Location = new Point(14 + (cw - 38) / 2 + 10, y),
+            Size = new Size((cw - 38) / 2, 24),
+            Font = UIFontSmall,
             PlaceholderText = "API key",
-            BackColor = PanelBg,
-            UseSystemPasswordChar = true,
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
-        };
-        apiPanel.Controls.Add(_txtApiKey);
-
-        y += 70;
-
-        // --- Queue stats ---
-        var lblQueues = new Label
-        {
-            Text = "QUEUE",
-            Font = UIFontSmall,
-            ForeColor = Color.Gray,
-            Location = new Point(Pad, y),
-            AutoSize = true
-        };
-        Controls.Add(lblQueues);
-        y += 16;
-
-        _listQueues = new ListView
-        {
-            Location = new Point(Pad, y),
-            Size = new Size(InnerWidth, 40),
-            View = View.Details,
-            FullRowSelect = true,
-            Font = UIFontSmall,
-            BackColor = PanelBg,
             BorderStyle = BorderStyle.FixedSingle,
-            HeaderStyle = ColumnHeaderStyle.Nonclickable,
-            GridLines = true,
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
+            BackColor = Color.White,
+            UseSystemPasswordChar = true,
+            Anchor = AnchorStyles.Top | AnchorStyles.Right,
         };
-        _listQueues.Columns.Add("Queue", 70);
-        _listQueues.Columns.Add("Queued", 50, HorizontalAlignment.Right);
-        _listQueues.Columns.Add("Started", 50, HorizontalAlignment.Right);
-        _listQueues.Columns.Add("Failed", 50, HorizontalAlignment.Right);
-        _listQueues.Columns.Add("Finished", 55, HorizontalAlignment.Right);
-        Controls.Add(_listQueues);
-        y += 46;
+        card.Controls.Add(_txtApiKey);
+        y += 30;
 
-        // --- Workers header + add button ---
-        var lblWorkers = new Label
+        card.Controls.Add(MakeDivider(14, y, cw - 28));
+        y += 10;
+
+        _queueStats = new QueueStatsBar
+        {
+            Location = new Point(14, y),
+            Size = new Size(cw - 28, 22),
+            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
+        };
+        card.Controls.Add(_queueStats);
+        y += 28;
+
+        var cardHeight = y + 6;
+        card.Height = cardHeight;
+        outer.Height = cardHeight + Pad / 2 + 4;
+
+        outer.Controls.Add(card);
+        Controls.Add(outer);
+    }
+
+    private void BuildWorkerHeader()
+    {
+        var formW = ClientSize.Width;
+        var header = new Panel
+        {
+            Dock = DockStyle.Top,
+            Height = 40,
+            Width = formW,
+            BackColor = BgColor,
+        };
+
+        var lbl = new Label
         {
             Text = "WORKERS",
-            Font = UIFontSmall,
-            ForeColor = Color.Gray,
-            Location = new Point(Pad, y + 4),
-            AutoSize = true
+            Font = SectionFont,
+            ForeColor = SectionLabelColor,
+            Location = new Point(Pad, 12),
+            AutoSize = true,
         };
-        Controls.Add(lblWorkers);
+        header.Controls.Add(lbl);
+
+        _btnToggleLog = new Button
+        {
+            Text = "\u25c0 Log",
+            Size = new Size(64, 28),
+            FlatStyle = FlatStyle.Flat,
+            BackColor = Color.FromArgb(0x47, 0x55, 0x69),
+            ForeColor = Color.White,
+            Font = UIFontSmall,
+            Cursor = Cursors.Hand,
+            Anchor = AnchorStyles.Top | AnchorStyles.Right,
+        };
+        _btnToggleLog.FlatAppearance.BorderSize = 0;
+        _btnToggleLog.Location = new Point(formW - Pad - _btnToggleLog.Width, 6);
+        _btnToggleLog.Click += (_, _) => ToggleLogPanel();
+        header.Controls.Add(_btnToggleLog);
 
         _btnAddWorker = new Button
         {
             Text = "+ Add Worker",
-            Size = new Size(90, 24),
+            Size = new Size(100, 28),
             FlatStyle = FlatStyle.Flat,
             BackColor = AccentGreen,
             ForeColor = Color.White,
             Font = UIFontSmall,
             Cursor = Cursors.Hand,
             Enabled = false,
-            Anchor = AnchorStyles.Top | AnchorStyles.Right
+            Anchor = AnchorStyles.Top | AnchorStyles.Right,
         };
-        _btnAddWorker.Location = new Point(Pad + InnerWidth - _btnAddWorker.Width, y);
         _btnAddWorker.FlatAppearance.BorderSize = 0;
+        _btnAddWorker.Location = new Point(_btnToggleLog.Left - _btnAddWorker.Width - 8, 6);
         _btnAddWorker.Click += BtnAddWorker_Click;
-        Controls.Add(_btnAddWorker);
-        y += 28;
+        header.Controls.Add(_btnAddWorker);
 
-        // --- Worker list ---
-        var listHeight = 100;
-        _listWorkers = new ListView
-        {
-            Location = new Point(Pad, y),
-            Size = new Size(InnerWidth, listHeight),
-            View = View.Details,
-            FullRowSelect = true,
-            Font = UIFontSmall,
-            BackColor = PanelBg,
-            BorderStyle = BorderStyle.FixedSingle,
-            HeaderStyle = ColumnHeaderStyle.Nonclickable,
-            GridLines = true,
-            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right
-        };
-        _listWorkers.Columns.Add("Worker", 120);
-        _listWorkers.Columns.Add("State", 60);
-        _listWorkers.Columns.Add("Job", 90);
-        _listWorkers.Columns.Add("", 30);
-        Controls.Add(_listWorkers);
-        y += listHeight + 6;
+        Controls.Add(header);
+    }
 
-        // --- Log panel ---
-        var lblLog = new Label
+    private void BuildMainArea()
+    {
+        _splitMain = new SplitContainer
         {
-            Text = "LOG",
-            Font = UIFontSmall,
-            ForeColor = Color.Gray,
-            Location = new Point(Pad, y),
-            AutoSize = true
+            Dock = DockStyle.Fill,
+            Orientation = Orientation.Vertical,
+            BackColor = BgColor,
+            SplitterWidth = 4,
+            SplitterDistance = 580,
+            Panel1MinSize = 25,
+            Panel2MinSize = 25,
         };
-        Controls.Add(lblLog);
-        y += 16;
 
-        _txtLog = new TextBox
+        _workerGrid = new FlowLayoutPanel
         {
-            Location = new Point(Pad, y),
-            Size = new Size(InnerWidth, ClientSize.Height - y - Pad),
-            Multiline = true,
-            ReadOnly = true,
-            ScrollBars = ScrollBars.Vertical,
-            Font = new Font("Consolas", 7.5f),
-            BackColor = Color.FromArgb(0x1e, 0x1e, 0x1e),
-            ForeColor = Color.FromArgb(0xcc, 0xcc, 0xcc),
-            BorderStyle = BorderStyle.FixedSingle,
-            WordWrap = false,
-            Anchor = AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right
+            Dock = DockStyle.Fill,
+            AutoScroll = true,
+            BackColor = BgColor,
+            Padding = new Padding(Pad - 6, 6, Pad - 6, 6),
+            WrapContents = true,
         };
-        Controls.Add(_txtLog);
+        _splitMain.Panel1.Controls.Add(_workerGrid);
+
+        BuildLogPanel();
 
         AppLog.LogAdded += line =>
         {
+            if (IsDisposed) return;
             if (InvokeRequired)
             {
-                try { BeginInvoke(() => AppendLog(line)); } catch { }
+                try { BeginInvoke(() => AppendLog(line)); }
+                catch { }
                 return;
             }
             AppendLog(line);
         };
 
-        var ctxMenu = new ContextMenuStrip();
-        var stopItem = new ToolStripMenuItem("Stop Worker");
-        stopItem.Click += (_, _) =>
-        {
-            if (_listWorkers.SelectedItems.Count > 0)
-            {
-                var name = _listWorkers.SelectedItems[0].Text;
-                if (name != "ERROR")
-                    _trayContext.ProcessManager.StopWorker(name);
-            }
-        };
-        ctxMenu.Items.Add(stopItem);
-        _listWorkers.ContextMenuStrip = ctxMenu;
+        Controls.Add(_splitMain);
+    }
 
-        _listWorkers.MouseClick += (_, e) =>
+    private void BuildLogPanel()
+    {
+        var logHeader = new Panel
         {
-            if (e.Button != MouseButtons.Left) return;
-            var hit = _listWorkers.HitTest(e.Location);
-            if (hit.Item != null && hit.SubItem != null && hit.Item.SubItems.IndexOf(hit.SubItem) == 3)
-            {
-                var name = hit.Item.Text;
-                if (name != "ERROR")
-                    _trayContext.ProcessManager.StopWorker(name);
-            }
+            Dock = DockStyle.Top,
+            Height = 34,
+            BackColor = Color.FromArgb(0x1E, 0x29, 0x3B),
+        };
+
+        _lblLogTitle = new Label
+        {
+            Text = "LOG",
+            Font = SectionFont,
+            ForeColor = Color.FromArgb(0x94, 0xA3, 0xB8),
+            Location = new Point(12, 10),
+            AutoSize = true,
+        };
+        logHeader.Controls.Add(_lblLogTitle);
+
+        _btnWrapToggle = new Label
+        {
+            Text = "wrap",
+            Font = UIFontSmall,
+            ForeColor = Color.FromArgb(0x64, 0x74, 0x8B),
+            Cursor = Cursors.Hand,
+            AutoSize = true,
+        };
+        _btnWrapToggle.Click += (_, _) => ToggleWordWrap();
+        logHeader.Controls.Add(_btnWrapToggle);
+
+        _btnClearFilter = new Label
+        {
+            Text = "\u2715 clear",
+            Font = UIFontSmall,
+            ForeColor = Color.FromArgb(0x64, 0x74, 0x8B),
+            Cursor = Cursors.Hand,
+            AutoSize = true,
+            Visible = false,
+        };
+        _btnClearFilter.Click += (_, _) => SelectWorkerCard(null);
+        logHeader.Controls.Add(_btnClearFilter);
+
+        _splitMain.Panel2.Resize += (_, _) => PositionLogHeaderButtons();
+
+        _txtLog = new TextBox
+        {
+            Dock = DockStyle.Fill,
+            Multiline = true,
+            ReadOnly = true,
+            ScrollBars = ScrollBars.Both,
+            Font = LogFont,
+            BackColor = LogBg,
+            ForeColor = LogFg,
+            BorderStyle = BorderStyle.None,
+            WordWrap = false,
+        };
+
+        _splitMain.Panel2.Controls.Add(_txtLog);
+        _splitMain.Panel2.Controls.Add(logHeader);
+    }
+
+    private static Panel MakeDivider(int x, int y, int width)
+    {
+        return new Panel
+        {
+            Location = new Point(x, y),
+            Size = new Size(width, 1),
+            BackColor = CardBorder,
+            Anchor = AnchorStyles.Top | AnchorStyles.Left | AnchorStyles.Right,
         };
     }
 
-    private void LoadSettings()
+    // ──────────────────────────────────────────────
+    //  Public API (called from TrayApplicationContext)
+    // ──────────────────────────────────────────────
+
+    public void OnAutoConnected()
     {
-        _settings = AppSettings.Load();
-        _txtRedisUrl.Text = _settings.RedisUrl;
-        _txtApiGatewayUrl.Text = _settings.ApiGatewayUrl ?? "";
-        _txtApiKey.Text = _settings.ApiKey ?? "";
+        if (!_initialized) return;
+        if (InvokeRequired) { try { BeginInvoke(OnAutoConnected); } catch { } return; }
+        _btnConnect.Text = "Reconnect";
+        UpdateStatusLabel();
+        StartStatsTimer();
     }
 
-    private void SubscribeToEvents()
+    public void UpdateWorkerRow(string workerName, string state, string? jobId, string? modelPath = null)
     {
-        _trayContext.RedisMonitor.ConnectionStateChanged += (_, _) =>
+        if (!_initialized || IsDisposed) return;
+        if (InvokeRequired)
         {
-            if (InvokeRequired) { BeginInvoke(UpdateStatusLabel); return; }
-            UpdateStatusLabel();
-        };
-        _trayContext.ProcessManager.WorkerError += (_, e) =>
-        {
-            if (InvokeRequired) { BeginInvoke(() => ShowWorkerError(e.Message)); return; }
-            ShowWorkerError(e.Message);
-        };
-    }
-
-    private void UpdateStatusLabel()
-    {
-        var connected = _trayContext.RedisMonitor.IsConnected;
-        if (connected)
-        {
-            _lblStatus.Text = "\u25cf Connected";
-            _lblStatus.ForeColor = AccentGreen;
+            try { BeginInvoke(() => UpdateWorkerRow(workerName, state, jobId, modelPath)); }
+            catch { }
+            return;
         }
-        else
-        {
-            _lblStatus.Text = "\u25cf Disconnected";
-            _lblStatus.ForeColor = AccentRed;
-        }
-        _btnAddWorker.Enabled = connected;
-    }
 
-    public void UpdateWorkerRow(string workerName, string state, string? jobId)
-    {
-        if (IsDisposed) return;
         if (state == "stopped")
         {
-            var toRemove = _listWorkers.Items.Cast<ListViewItem>().FirstOrDefault(i => i.Text == workerName);
-            if (toRemove != null) _listWorkers.Items.Remove(toRemove);
+            RemoveWorkerCard(workerName);
             SaveCurrentWorkerCount();
             return;
         }
 
-        var existing = _listWorkers.Items.Cast<ListViewItem>().FirstOrDefault(i => i.Text == workerName);
-        if (existing != null)
+        if (_workerCards.TryGetValue(workerName, out var card))
+            card.UpdateState(state, jobId, modelPath);
+        else
+            AddWorkerCard(workerName, state, jobId, modelPath);
+    }
+
+    // ──────────────────────────────────────────────
+    //  Adopted job card management
+    // ──────────────────────────────────────────────
+
+    public void OnAdoptedJobStarted(AdoptedJobEventArgs e)
+    {
+        if (!_initialized || IsDisposed) return;
+        if (InvokeRequired) { try { BeginInvoke(() => OnAdoptedJobStarted(e)); } catch { } return; }
+
+        if (_adoptedCards.ContainsKey(e.JobId)) return;
+        var card = new AdoptedJobCard(e.JobId, e.OriginalWorkerName, e.Pid, e.AdoptedAt, e.ModelPath);
+        _adoptedCards[e.JobId] = card;
+        _workerGrid.Controls.Add(card);
+    }
+
+    public void OnAdoptedJobFinished(AdoptedJobEventArgs e)
+    {
+        if (!_initialized || IsDisposed) return;
+        if (InvokeRequired) { try { BeginInvoke(() => OnAdoptedJobFinished(e)); } catch { } return; }
+
+        if (!_adoptedCards.TryGetValue(e.JobId, out var card)) return;
+        card.MarkDone(e.Success);
+        // Remove the card after a short delay so the user can see the final state
+        var t = new System.Windows.Forms.Timer { Interval = 4000 };
+        t.Tick += (_, _) =>
         {
-            existing.SubItems[1].Text = state;
-            existing.SubItems[2].Text = jobId ?? "";
+            t.Stop(); t.Dispose();
+            _workerGrid.Controls.Remove(card);
+            _adoptedCards.Remove(e.JobId);
+            card.Dispose();
+        };
+        t.Start();
+    }
+
+    // ──────────────────────────────────────────────
+    //  Worker card management
+    // ──────────────────────────────────────────────
+
+    private void AddWorkerCard(string workerName, string state, string? jobId, string? modelPath = null)
+    {
+        var card = new WorkerCard(workerName);
+        card.UpdateState(state, jobId, modelPath);
+        card.StopRequested += c => _trayContext.ProcessManager.StopWorker(c.WorkerName);
+        card.Clicked += c => SelectWorkerCard(c.IsSelected ? null : c);
+        _workerCards[workerName] = card;
+        _workerGrid.Controls.Add(card);
+    }
+
+    private void RemoveWorkerCard(string workerName)
+    {
+        if (!_workerCards.TryGetValue(workerName, out var card)) return;
+        if (_selectedWorker == workerName)
+            SelectWorkerCard(null);
+        _workerGrid.Controls.Remove(card);
+        _workerCards.Remove(workerName);
+        card.Dispose();
+    }
+
+    private void ClearAllWorkerCards()
+    {
+        _selectedWorker = null;
+        foreach (var card in _workerCards.Values)
+            card.Dispose();
+        _workerCards.Clear();
+        foreach (var card in _adoptedCards.Values)
+            card.Dispose();
+        _adoptedCards.Clear();
+        _workerGrid.Controls.Clear();
+        UpdateLogTitle();
+    }
+
+    private void SelectWorkerCard(WorkerCard? card)
+    {
+        if (_selectedWorker != null && _workerCards.TryGetValue(_selectedWorker, out var prev))
+            prev.IsSelected = false;
+
+        if (card != null && !card.IsSelected)
+        {
+            card.IsSelected = true;
+            _selectedWorker = card.WorkerName;
         }
         else
         {
-            var item = new ListViewItem(workerName);
-            item.SubItems.Add(state);
-            item.SubItems.Add(jobId ?? "");
-            item.SubItems.Add("\u00d7");
-            _listWorkers.Items.Add(item);
+            _selectedWorker = null;
+        }
+
+        UpdateLogTitle();
+        RebuildLog();
+    }
+
+    // ──────────────────────────────────────────────
+    //  Log management
+    // ──────────────────────────────────────────────
+
+    private void AppendLog(string line)
+    {
+        if (_txtLog == null || _txtLog.IsDisposed) return;
+
+        _allLogLines.Add(line);
+        if (_allLogLines.Count > 5000)
+            _allLogLines.RemoveRange(0, 1000);
+
+        if (!MatchesFilter(line)) return;
+
+        if (_txtLog.TextLength > 80_000)
+            RebuildLog();
+        else
+            _txtLog.AppendText(line + Environment.NewLine);
+    }
+
+    private bool MatchesFilter(string line)
+    {
+        return _selectedWorker == null || line.Contains($"[{_selectedWorker}]");
+    }
+
+    private void RebuildLog()
+    {
+        if (_txtLog == null || _txtLog.IsDisposed) return;
+
+        IEnumerable<string> lines = _selectedWorker != null
+            ? _allLogLines.Where(l => l.Contains($"[{_selectedWorker}]"))
+            : _allLogLines;
+
+        _txtLog.Text = string.Join(Environment.NewLine, lines.TakeLast(3000));
+        if (_txtLog.TextLength > 0)
+        {
+            _txtLog.SelectionStart = _txtLog.TextLength;
+            _txtLog.ScrollToCaret();
         }
     }
 
-    private void ShowWorkerError(string message)
+    private void UpdateLogTitle()
     {
-        var item = new ListViewItem("ERROR");
-        item.SubItems.Add("");
-        item.SubItems.Add(message.Length > 60 ? message[..60] + "..." : message);
-        item.SubItems.Add("");
-        item.ForeColor = Color.Red;
-        _listWorkers.Items.Add(item);
-        if (_listWorkers.Items.Count > 50)
-            _listWorkers.Items.RemoveAt(0);
-        _listWorkers.EnsureVisible(_listWorkers.Items.Count - 1);
+        if (_lblLogTitle == null) return;
+        _lblLogTitle.Text = _selectedWorker != null ? $"LOG \u2014 {_selectedWorker}" : "LOG";
+        if (_btnClearFilter != null)
+            _btnClearFilter.Visible = _selectedWorker != null;
     }
+
+    private void ToggleWordWrap()
+    {
+        if (_txtLog == null) return;
+        _txtLog.WordWrap = !_txtLog.WordWrap;
+        _txtLog.ScrollBars = _txtLog.WordWrap ? ScrollBars.Vertical : ScrollBars.Both;
+        if (_btnWrapToggle != null)
+            _btnWrapToggle.ForeColor = _txtLog.WordWrap ? AccentBlue : Color.FromArgb(0x64, 0x74, 0x8B);
+    }
+
+    private void PositionLogHeaderButtons()
+    {
+        var w = _splitMain.Panel2.Width;
+        if (_btnWrapToggle != null)
+            _btnWrapToggle.Location = new Point(Math.Max(60, w - _btnWrapToggle.Width - 12), 10);
+        if (_btnClearFilter != null)
+            _btnClearFilter.Location = new Point(
+                Math.Max(60, w - (_btnWrapToggle?.Width ?? 0) - _btnClearFilter.Width - 20), 10);
+    }
+
+    private void ToggleLogPanel()
+    {
+        _logVisible = !_logVisible;
+        _btnToggleLog.Text = _logVisible ? "\u25c0 Log" : "Log \u25b6";
+
+        if (_logVisible)
+        {
+            _splitMain.Panel2Collapsed = false;
+            try
+            {
+                _splitMain.Panel1MinSize = 280;
+                _splitMain.Panel2MinSize = 240;
+                _splitMain.SplitterDistance = Math.Max(280, _splitMain.Width - 380);
+            }
+            catch { }
+            if (Width < 850)
+                Width = Math.Min(1000, Screen.PrimaryScreen?.WorkingArea.Width ?? 1000);
+            RebuildLog();
+        }
+        else
+        {
+            _splitMain.Panel2Collapsed = true;
+            _splitMain.Panel1MinSize = 25;
+            _splitMain.Panel2MinSize = 25;
+        }
+    }
+
+    // ──────────────────────────────────────────────
+    //  Event handlers
+    // ──────────────────────────────────────────────
 
     private void BtnConnect_Click(object? sender, EventArgs e)
     {
@@ -402,33 +630,52 @@ public sealed class MainForm : Form
         }
 
         _btnConnect.Enabled = false;
-        _btnConnect.Text = "...";
-        _listWorkers.Items.Clear();
-        try
-        {
-            _trayContext.ProcessManager.StopAll();
-            _trayContext.RedisMonitor.Connect(url);
-            _settings.RedisUrl = url;
-            _settings.QueueNames = AppSettings.DefaultQueueNames;
-            _settings.ApiGatewayUrl = string.IsNullOrWhiteSpace(_txtApiGatewayUrl.Text) ? null : _txtApiGatewayUrl.Text.Trim();
-            _settings.ApiKey = string.IsNullOrWhiteSpace(_txtApiKey.Text) ? null : _txtApiKey.Text.Trim();
-            _settings.Save();
+        _btnConnect.Text = "\u2026";
+        ClearAllWorkerCards();
 
-            _trayContext.ProcessManager.Configure(url, _settings.QueueNames, _settings.JobStartDelaySeconds);
-            _trayContext.ProcessManager.SetConnection(_trayContext.RedisMonitor.Connection!);
+        var apiUrl = string.IsNullOrWhiteSpace(_txtApiGatewayUrl.Text) ? null : _txtApiGatewayUrl.Text.Trim();
+        var apiKey = string.IsNullOrWhiteSpace(_txtApiKey.Text) ? null : _txtApiKey.Text.Trim();
 
-            _btnConnect.Text = "Reconnect";
-            _btnConnect.Enabled = true;
-            UpdateStatusLabel();
-            StartStatsTimer();
-        }
-        catch (Exception ex)
+        Task.Run(() =>
         {
-            _btnConnect.Text = "Connect";
-            _btnConnect.Enabled = true;
-            UpdateStatusLabel();
-            MessageBox.Show("Failed to connect:\n" + ex.Message, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
-        }
+            try
+            {
+                _trayContext.ProcessManager.StopAll();
+                _trayContext.RedisMonitor.Connect(url);
+
+                BeginInvoke(() =>
+                {
+                    _settings.RedisUrl = url;
+                    _settings.QueueNames = AppSettings.DefaultQueueNames;
+                    _settings.ApiGatewayUrl = apiUrl;
+                    _settings.ApiKey = apiKey;
+                    _settings.Save();
+
+                    _trayContext.ProcessManager.Configure(url, _settings.QueueNames, _settings.JobStartDelaySeconds);
+                    _trayContext.ProcessManager.SetConnection(_trayContext.RedisMonitor.Connection!);
+
+                    _btnConnect.Text = "Reconnect";
+                    _btnConnect.Enabled = true;
+                    UpdateStatusLabel();
+                    StartStatsTimer();
+                });
+            }
+            catch (Exception ex)
+            {
+                var msg = ex.Message;
+                try
+                {
+                    BeginInvoke(() =>
+                    {
+                        _btnConnect.Text = "Connect";
+                        _btnConnect.Enabled = true;
+                        UpdateStatusLabel();
+                        MessageBox.Show("Failed to connect:\n" + msg, Text, MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    });
+                }
+                catch { }
+            }
+        });
     }
 
     private void BtnAddWorker_Click(object? sender, EventArgs e)
@@ -448,11 +695,55 @@ public sealed class MainForm : Form
         }
     }
 
+    // ──────────────────────────────────────────────
+    //  Settings & subscriptions
+    // ──────────────────────────────────────────────
+
+    private void LoadSettings()
+    {
+        _settings = AppSettings.Load();
+        _txtRedisUrl.Text = _settings.RedisUrl;
+        _txtApiGatewayUrl.Text = _settings.ApiGatewayUrl ?? "";
+        _txtApiKey.Text = _settings.ApiKey ?? "";
+    }
+
+    private void SubscribeToEvents()
+    {
+        _trayContext.RedisMonitor.ConnectionStateChanged += (_, _) =>
+        {
+            if (IsDisposed) return;
+            if (InvokeRequired) { try { BeginInvoke(UpdateStatusLabel); } catch { } return; }
+            UpdateStatusLabel();
+        };
+    }
+
+    private void UpdateStatusLabel()
+    {
+        var connected = _trayContext.RedisMonitor.IsConnected;
+        if (connected)
+        {
+            _lblStatus.Text = "\u25cf Connected";
+            _lblStatus.ForeColor = AccentGreen;
+            _btnConnect.Text = "Reconnect";
+            StartStatsTimer();
+        }
+        else
+        {
+            _lblStatus.Text = "\u25cf Disconnected (auto-reconnecting\u2026)";
+            _lblStatus.ForeColor = AccentRed;
+        }
+        _btnAddWorker.Enabled = connected;
+    }
+
     private void SaveCurrentWorkerCount()
     {
         _settings.WorkerCount = _trayContext.ProcessManager.CurrentCount;
         try { _settings.Save(); } catch { }
     }
+
+    // ──────────────────────────────────────────────
+    //  Timers
+    // ──────────────────────────────────────────────
 
     private void StartStatsTimer()
     {
@@ -463,52 +754,71 @@ public sealed class MainForm : Form
         RefreshQueueStats();
     }
 
+    private void StartDurationTimer()
+    {
+        _durationTimer = new System.Windows.Forms.Timer { Interval = 1000 };
+        _durationTimer.Tick += (_, _) =>
+        {
+            foreach (var card in _workerCards.Values)
+                card.UpdateDuration();
+            foreach (var card in _adoptedCards.Values)
+                card.UpdateDuration();
+        };
+        _durationTimer.Start();
+    }
+
+    private volatile bool _refreshingStats;
+
     private void RefreshQueueStats()
     {
         var conn = _trayContext.RedisMonitor.Connection;
-        if (conn == null || !conn.IsConnected) return;
+        if (conn == null || !conn.IsConnected || _refreshingStats) return;
+        _refreshingStats = true;
 
-        try
+        var queueNames = (_settings.QueueNames ?? AppSettings.DefaultQueueNames)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        Task.Run(() =>
         {
-            var db = conn.GetDatabase();
-            var queues = (_settings.QueueNames ?? AppSettings.DefaultQueueNames)
-                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-
-            _listQueues.BeginUpdate();
-            _listQueues.Items.Clear();
-            var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-            foreach (var q in queues)
+            try
             {
-                var queued = db.ListLength($"rq:queue:{q}");
-                var started = db.SortedSetLength($"rq:wip:{q}", now, double.PositiveInfinity);
-                var failed = db.SortedSetLength($"rq:failed:{q}");
-                var finished = db.SortedSetLength($"rq:finished:{q}");
-
-                var item = new ListViewItem(q);
-                item.SubItems.Add(queued.ToString());
-                item.SubItems.Add(started.ToString());
-                item.SubItems.Add(failed.ToString());
-                item.SubItems.Add(finished.ToString());
-                _listQueues.Items.Add(item);
+                var db = conn.GetDatabase();
+                var now = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+                long totalQueued = 0, totalActive = 0, totalFailed = 0, totalDone = 0;
+                var name = "";
+                foreach (var q in queueNames)
+                {
+                    name = q;
+                    totalQueued += db.ListLength($"rq:queue:{q}");
+                    totalActive += db.SortedSetLength($"rq:wip:{q}", now, double.PositiveInfinity);
+                    totalFailed += db.SortedSetLength($"rq:failed:{q}");
+                    totalDone += db.SortedSetLength($"rq:finished:{q}");
+                }
+                var n = name; var tq = totalQueued; var ta = totalActive; var tf = totalFailed; var td = totalDone;
+                try { BeginInvoke(() => _queueStats.Update(n, tq, ta, tf, td)); } catch { }
             }
-            _listQueues.EndUpdate();
-        }
-        catch { }
+            catch { }
+            finally { _refreshingStats = false; }
+        });
     }
 
-    private void AppendLog(string line)
-    {
-        if (_txtLog.IsDisposed) return;
-        if (_txtLog.TextLength > 60_000)
-            _txtLog.Text = _txtLog.Text.Substring(_txtLog.TextLength - 40_000);
-        _txtLog.AppendText(line + Environment.NewLine);
-    }
+    // ──────────────────────────────────────────────
+    //  Lifecycle
+    // ──────────────────────────────────────────────
 
     protected override void OnShown(EventArgs e)
     {
         base.OnShown(e);
         foreach (var line in AppLog.GetBuffer())
             AppendLog(line);
+
+        try
+        {
+            _splitMain.Panel1MinSize = 280;
+            _splitMain.Panel2MinSize = 240;
+            _splitMain.SplitterDistance = Math.Max(280, _splitMain.Width - 380);
+        }
+        catch { }
     }
 
     protected override void Dispose(bool disposing)
@@ -517,7 +827,473 @@ public sealed class MainForm : Form
         {
             _statsTimer?.Stop();
             _statsTimer?.Dispose();
+            _durationTimer?.Stop();
+            _durationTimer?.Dispose();
         }
         base.Dispose(disposing);
+    }
+
+    // ══════════════════════════════════════════════
+    //  QueueStatsBar — inline colored stat display
+    // ══════════════════════════════════════════════
+
+    private sealed class QueueStatsBar : Panel
+    {
+        private static readonly Font NameFont = new("Segoe UI Semibold", 8.5f);
+        private static readonly Font NumFont = new("Segoe UI Semibold", 8.5f);
+        private static readonly Font LabelFont = new("Segoe UI", 7.5f);
+
+        private string _queue = "";
+        private long _queued, _active, _failed, _done;
+
+        public QueueStatsBar()
+        {
+            BackColor = Color.Transparent;
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.UserPaint | ControlStyles.OptimizedDoubleBuffer, true);
+        }
+
+        public void Update(string queue, long queued, long active, long failed, long done)
+        {
+            _queue = queue; _queued = queued; _active = active; _failed = failed; _done = done;
+            Invalidate();
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            var g = e.Graphics;
+            g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+
+            float x = 0;
+            using var nameBrush = new SolidBrush(Color.FromArgb(0x33, 0x41, 0x55));
+            g.DrawString(_queue, NameFont, nameBrush, x, 2);
+            x += g.MeasureString(_queue, NameFont).Width + 12;
+
+            DrawStat(g, ref x, _queued.ToString(), "queued", Color.FromArgb(0x64, 0x74, 0x8B));
+            DrawStat(g, ref x, _active.ToString(), "active", AccentOrange);
+            DrawStat(g, ref x, _failed.ToString(), "failed", AccentRed);
+            DrawStat(g, ref x, _done.ToString(), "done", AccentGreen);
+        }
+
+        private void DrawStat(Graphics g, ref float x, string num, string label, Color color)
+        {
+            using var numBrush = new SolidBrush(color);
+            using var lblBrush = new SolidBrush(Muted);
+            g.DrawString(num, NumFont, numBrush, x, 2);
+            x += g.MeasureString(num, NumFont).Width - 2;
+            g.DrawString(label, LabelFont, lblBrush, x, 4);
+            x += g.MeasureString(label, LabelFont).Width + 8;
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    //  WorkerCard — custom-painted card
+    // ══════════════════════════════════════════════
+
+    private sealed class WorkerCard : Panel
+    {
+        private const int CardW = 190;
+        private const int CardH = 175;
+        private const int Radius = 10;
+        private const int DotSize = 14;
+
+        private static readonly Font NameFont = new("Segoe UI Semibold", 9.5f);
+        private static readonly Font StateFont = new("Segoe UI", 8.5f);
+        private static readonly Font JobFont = new("Segoe UI", 7.5f);
+        private static readonly Font TimeFont = new("Consolas", 14f, FontStyle.Bold);
+        private static readonly Font StopFont = new("Segoe UI", 14f);
+
+        private static readonly Rectangle StopBtnRect = new(CardW - 32, 4, 26, 26);
+
+        private string _state = "idle";
+        private string _displayState = "idle";
+        private Color _stateColor = AccentGreen;
+        private string? _jobId;
+        private string? _modelPath;
+        private DateTime? _busySince;
+        private bool _isSelected;
+        private bool _isHovering;
+        private string _displayTime = "--:--";
+
+        public string WorkerName { get; }
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set { _isSelected = value; Invalidate(); }
+        }
+
+        public event Action<WorkerCard>? StopRequested;
+        public event Action<WorkerCard>? Clicked;
+
+        public WorkerCard(string name)
+        {
+            WorkerName = name;
+            Size = new Size(CardW, CardH);
+            Margin = new Padding(6);
+            Cursor = Cursors.Hand;
+            BackColor = BgColor;
+
+            SetStyle(
+                ControlStyles.AllPaintingInWmPaint |
+                ControlStyles.UserPaint |
+                ControlStyles.OptimizedDoubleBuffer |
+                ControlStyles.ResizeRedraw,
+                true);
+
+            UpdateRegion();
+        }
+
+        public void UpdateState(string state, string? jobId, string? modelPath = null)
+        {
+            _state = state;
+            _jobId = jobId;
+            _modelPath = modelPath;
+
+            if (state == "busy" && _busySince == null)
+                _busySince = DateTime.UtcNow;
+            else if (state != "busy" && !state.StartsWith("start-delay"))
+                _busySince = null;
+
+            var (ds, color, countdown) = ParseState(state);
+            _displayState = ds;
+            _stateColor = color;
+
+            if (countdown != null)
+                _displayTime = countdown;
+            else if (state == "idle")
+                _displayTime = "--:--";
+
+            Invalidate();
+        }
+
+        public void UpdateDuration()
+        {
+            if (_busySince.HasValue)
+            {
+                var elapsed = DateTime.UtcNow - _busySince.Value;
+                var t = elapsed.TotalHours >= 1
+                    ? $"{(int)elapsed.TotalHours}:{elapsed.Minutes:D2}:{elapsed.Seconds:D2}"
+                    : $"{elapsed.Minutes:D2}:{elapsed.Seconds:D2}";
+                if (t != _displayTime) { _displayTime = t; Invalidate(); }
+            }
+        }
+
+        protected override void OnMouseMove(MouseEventArgs e)
+        {
+            base.OnMouseMove(e);
+            if (!_isHovering) { _isHovering = true; Invalidate(); }
+        }
+
+        protected override void OnMouseLeave(EventArgs e)
+        {
+            base.OnMouseLeave(e);
+            if (_isHovering) { _isHovering = false; Invalidate(); }
+        }
+
+        protected override void OnMouseClick(MouseEventArgs e)
+        {
+            base.OnMouseClick(e);
+            if (e.Button != MouseButtons.Left) return;
+            if (_isHovering && StopBtnRect.Contains(e.Location))
+                StopRequested?.Invoke(this);
+            else
+                Clicked?.Invoke(this);
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+
+            var rect = new Rectangle(0, 0, Width - 1, Height - 1);
+            using var bgPath = RoundedRect(rect, Radius);
+
+            if (_isHovering && !_isSelected)
+            {
+                using var shadow = new SolidBrush(Color.FromArgb(8, 0, 0, 0));
+                g.FillPath(shadow, RoundedRect(new Rectangle(1, 2, Width - 1, Height - 1), Radius));
+            }
+
+            g.FillPath(Brushes.White, bgPath);
+
+            var borderColor = _isSelected ? SelectedBorder
+                : _isHovering ? Color.FromArgb(0xBD, 0xC5, 0xD0)
+                : CardBorder;
+            using var borderPen = new Pen(borderColor, _isSelected ? 2f : 1f);
+            g.DrawPath(borderPen, bgPath);
+
+            var nameText = WorkerName.Length > 16 ? WorkerName[..13] + "\u2026" : WorkerName;
+            using var nameBrush = new SolidBrush(Color.FromArgb(0x1E, 0x29, 0x3B));
+            g.DrawString(nameText, NameFont, nameBrush, 14, 14);
+
+            if (_isHovering)
+            {
+                var mp = PointToClient(Control.MousePosition);
+                var stopColor = StopBtnRect.Contains(mp) ? AccentRed : Muted;
+                using var stopBrush = new SolidBrush(stopColor);
+                g.DrawString("\u00d7", StopFont, stopBrush, StopBtnRect.X, StopBtnRect.Y);
+            }
+
+            var dotX = (Width - DotSize) / 2;
+            var dotY = 48;
+
+            if (_state == "busy")
+            {
+                using var glow = new SolidBrush(Color.FromArgb(25, _stateColor));
+                g.FillEllipse(glow, dotX - 8, dotY - 8, DotSize + 16, DotSize + 16);
+            }
+
+            using var dotBrush = new SolidBrush(_stateColor);
+            g.FillEllipse(dotBrush, dotX, dotY, DotSize, DotSize);
+
+            using var stateBrush = new SolidBrush(_stateColor);
+            var stateSize = g.MeasureString(_displayState, StateFont);
+            g.DrawString(_displayState, StateFont, stateBrush,
+                (Width - stateSize.Width) / 2, 68);
+
+            if (!string.IsNullOrEmpty(_jobId))
+            {
+                var jobText = _jobId.Length > 22 ? _jobId[..19] + "\u2026" : _jobId;
+                using var jobBrush = new SolidBrush(Muted);
+                var jobSize = g.MeasureString(jobText, JobFont);
+                g.DrawString(jobText, JobFont, jobBrush,
+                    (Width - jobSize.Width) / 2, 90);
+
+                if (!string.IsNullOrEmpty(_modelPath))
+                {
+                    var fileName = System.IO.Path.GetFileNameWithoutExtension(_modelPath);
+                    var fileText = fileName.Length > 22 ? fileName[..19] + "\u2026" : fileName;
+                    var fileSize = g.MeasureString(fileText, JobFont);
+                    using var fileBrush = new SolidBrush(Color.FromArgb(0x47, 0x55, 0x69));
+                    g.DrawString(fileText, JobFont, fileBrush,
+                        (Width - fileSize.Width) / 2, 103);
+                }
+            }
+
+            var timeColor = _state == "busy" ? AccentOrange
+                : _state.StartsWith("start-delay") ? AccentAmber
+                : Muted;
+            using var timeBrush = new SolidBrush(timeColor);
+            var timeSize = g.MeasureString(_displayTime, TimeFont);
+            g.DrawString(_displayTime, TimeFont, timeBrush,
+                (Width - timeSize.Width) / 2, 120);
+        }
+
+        private void UpdateRegion()
+        {
+            using var path = RoundedRect(new Rectangle(0, 0, Width, Height), Radius);
+            Region?.Dispose();
+            Region = new Region(path);
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            UpdateRegion();
+        }
+
+        private static (string displayState, Color color, string? countdown) ParseState(string state)
+        {
+            if (state == "idle") return ("idle", AccentGreen, null);
+            if (state == "busy") return ("busy", AccentOrange, null);
+            if (state == "stopped") return ("stopped", Color.Gray, null);
+            if (state.StartsWith("start-delay"))
+            {
+                var m = Regex.Match(state, @"\((\d+)s\)");
+                return ("waiting", AccentAmber, m.Success ? m.Groups[1].Value + "s" : "\u2026");
+            }
+            return (state, Color.Gray, null);
+        }
+
+        private static GraphicsPath RoundedRect(Rectangle bounds, int radius)
+        {
+            var path = new GraphicsPath();
+            var d = radius * 2;
+            path.AddArc(bounds.X, bounds.Y, d, d, 180, 90);
+            path.AddArc(bounds.Right - d, bounds.Y, d, d, 270, 90);
+            path.AddArc(bounds.Right - d, bounds.Bottom - d, d, d, 0, 90);
+            path.AddArc(bounds.X, bounds.Bottom - d, d, d, 90, 90);
+            path.CloseFigure();
+            return path;
+        }
+    }
+
+    // ══════════════════════════════════════════════
+    //  AdoptedJobCard — inherited/handoff job monitor
+    // ══════════════════════════════════════════════
+
+    private sealed class AdoptedJobCard : Panel
+    {
+        private const int CardW = 190;
+        private const int CardH = 175;
+        private const int Radius = 10;
+        private const int DotSize = 14;
+
+        private static readonly Font BadgeFont  = new("Segoe UI", 7f, FontStyle.Bold);
+        private static readonly Font NameFont   = new("Segoe UI Semibold", 9f);
+        private static readonly Font StateFont  = new("Segoe UI", 8.5f);
+        private static readonly Font PidFont    = new("Segoe UI", 7.5f);
+        private static readonly Font TimeFont   = new("Consolas", 14f, FontStyle.Bold);
+
+        private static readonly Color CardAmber  = Color.FromArgb(0xD9, 0x77, 0x06);
+        private static readonly Color BadgeBg    = Color.FromArgb(0xFF, 0xF7, 0xED);
+        private static readonly Color BadgeFg    = Color.FromArgb(0xD9, 0x77, 0x06);
+
+        private readonly string _jobId;
+        private readonly string _workerName;
+        private readonly int _pid;
+        private readonly DateTime _adoptedAt;
+        private readonly string? _modelPath;
+        private string _displayTime = "00:00";
+        private bool _done;
+        private bool _doneSuccess;
+
+        public AdoptedJobCard(string jobId, string workerName, int pid, DateTime adoptedAt, string? modelPath = null)
+        {
+            _jobId = jobId;
+            _workerName = workerName;
+            _pid = pid;
+            _adoptedAt = adoptedAt;
+            _modelPath = modelPath;
+
+            Size = new Size(CardW, CardH);
+            Margin = new Padding(6);
+            BackColor = BgColor;
+
+            SetStyle(
+                ControlStyles.AllPaintingInWmPaint |
+                ControlStyles.UserPaint |
+                ControlStyles.OptimizedDoubleBuffer |
+                ControlStyles.ResizeRedraw,
+                true);
+
+            UpdateRegion();
+        }
+
+        public void UpdateDuration()
+        {
+            if (_done) return;
+            var elapsed = DateTime.UtcNow - _adoptedAt;
+            var t = elapsed.TotalHours >= 1
+                ? $"{(int)elapsed.TotalHours}:{elapsed.Minutes:D2}:{elapsed.Seconds:D2}"
+                : $"{elapsed.Minutes:D2}:{elapsed.Seconds:D2}";
+            if (t != _displayTime) { _displayTime = t; Invalidate(); }
+        }
+
+        public void MarkDone(bool success)
+        {
+            _done = true;
+            _doneSuccess = success;
+            Invalidate();
+        }
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            var g = e.Graphics;
+            g.SmoothingMode = SmoothingMode.AntiAlias;
+            g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+
+            var rect = new Rectangle(0, 0, Width - 1, Height - 1);
+            using var bgPath = RoundedRect(rect, Radius);
+
+            // White fill
+            using var bgBrush = new SolidBrush(Color.White);
+            g.FillPath(bgBrush, bgPath);
+
+            // Amber border (2px)
+            var borderColor = _done
+                ? (_doneSuccess ? AccentGreen : AccentRed)
+                : CardAmber;
+            using var borderPen = new Pen(borderColor, 2f);
+            g.DrawPath(borderPen, bgPath);
+
+            // "INHERITED" badge at top
+            var badgeText = "INHERITED";
+            var badgeSize = g.MeasureString(badgeText, BadgeFont);
+            var badgeRect = new RectangleF((Width - badgeSize.Width - 10) / 2, 8, badgeSize.Width + 10, badgeSize.Height + 4);
+            using var badgeBgBrush = new SolidBrush(BadgeBg);
+            using var badgePath = RoundedRect(Rectangle.Round(badgeRect), 3);
+            g.FillPath(badgeBgBrush, badgePath);
+            using var badgeFgBrush = new SolidBrush(BadgeFg);
+            g.DrawString(badgeText, BadgeFont, badgeFgBrush, badgeRect.X + 5, badgeRect.Y + 2);
+
+            // Worker name
+            var shortName = _workerName.Length > 20 ? _workerName[..17] + "\u2026" : _workerName;
+            var nameSize = g.MeasureString(shortName, NameFont);
+            using var nameBrush = new SolidBrush(Color.FromArgb(0x1E, 0x29, 0x3B));
+            g.DrawString(shortName, NameFont, nameBrush, (Width - nameSize.Width) / 2, 30);
+
+            // State dot
+            var dotX = (Width - DotSize) / 2;
+            var dotY = 52;
+            var dotColor = _done ? (_doneSuccess ? AccentGreen : AccentRed) : CardAmber;
+            if (!_done)
+            {
+                using var glow = new SolidBrush(Color.FromArgb(25, dotColor));
+                g.FillEllipse(glow, dotX - 8, dotY - 8, DotSize + 16, DotSize + 16);
+            }
+            using var dotBrush = new SolidBrush(dotColor);
+            g.FillEllipse(dotBrush, dotX, dotY, DotSize, DotSize);
+
+            // State label
+            var stateText = _done ? (_doneSuccess ? "finished" : "failed") : "monitoring";
+            using var stateBrush = new SolidBrush(dotColor);
+            var stateSize = g.MeasureString(stateText, StateFont);
+            g.DrawString(stateText, StateFont, stateBrush, (Width - stateSize.Width) / 2, 72);
+
+            // PID
+            var pidText = $"PID {_pid}";
+            using var pidBrush = new SolidBrush(Muted);
+            var pidSize = g.MeasureString(pidText, PidFont);
+            g.DrawString(pidText, PidFont, pidBrush, (Width - pidSize.Width) / 2, 90);
+
+            // Job ID (truncated)
+            var jobText = _jobId.Length > 22 ? _jobId[..19] + "\u2026" : _jobId;
+            var jobSize = g.MeasureString(jobText, PidFont);
+            g.DrawString(jobText, PidFont, pidBrush, (Width - jobSize.Width) / 2, 102);
+
+            // Model filename
+            if (!string.IsNullOrEmpty(_modelPath))
+            {
+                var fileName = System.IO.Path.GetFileNameWithoutExtension(_modelPath);
+                var fileText = fileName.Length > 22 ? fileName[..19] + "\u2026" : fileName;
+                var fileSize = g.MeasureString(fileText, PidFont);
+                using var fileBrush = new SolidBrush(Color.FromArgb(0x47, 0x55, 0x69));
+                g.DrawString(fileText, PidFont, fileBrush, (Width - fileSize.Width) / 2, 114);
+            }
+
+            // Timer
+            var timeColor = _done ? Muted : CardAmber;
+            using var timeBrush = new SolidBrush(timeColor);
+            var timeStr = _done ? (_doneSuccess ? "done" : "failed") : _displayTime;
+            var timeSize = g.MeasureString(timeStr, TimeFont);
+            g.DrawString(timeStr, TimeFont, timeBrush, (Width - timeSize.Width) / 2, 128);
+        }
+
+        private void UpdateRegion()
+        {
+            using var path = RoundedRect(new Rectangle(0, 0, Width, Height), Radius);
+            Region?.Dispose();
+            Region = new Region(path);
+        }
+
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            UpdateRegion();
+        }
+
+        private static GraphicsPath RoundedRect(Rectangle bounds, int radius)
+        {
+            var path = new GraphicsPath();
+            var d = radius * 2;
+            path.AddArc(bounds.X, bounds.Y, d, d, 180, 90);
+            path.AddArc(bounds.Right - d, bounds.Y, d, d, 270, 90);
+            path.AddArc(bounds.Right - d, bounds.Bottom - d, d, d, 0, 90);
+            path.AddArc(bounds.X, bounds.Bottom - d, d, d, 90, 90);
+            path.CloseFigure();
+            return path;
+        }
     }
 }

--- a/revit-worker/app/ProcessHandoff.cs
+++ b/revit-worker/app/ProcessHandoff.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+
+namespace RevitWorkerApp;
+
+/// <summary>
+/// Persists the set of active child processes to disk so a redeployed instance
+/// can reattach and continue monitoring them.
+/// </summary>
+public sealed class ProcessHandoff
+{
+    public List<HandoffEntry> ActiveJobs { get; set; } = new();
+    public string WrittenAt { get; set; } = "";
+
+    public static string FilePath =>
+        Path.Combine(AppContext.BaseDirectory, "handoff.json");
+
+    public void Save()
+    {
+        WrittenAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ");
+        var json = JsonSerializer.Serialize(this, new JsonSerializerOptions { WriteIndented = true });
+        var tmp = FilePath + ".tmp";
+        File.WriteAllText(tmp, json);
+        File.Move(tmp, FilePath, overwrite: true);
+    }
+
+    /// <summary>
+    /// Load and atomically delete the handoff file.
+    /// Returns null if the file does not exist or cannot be parsed.
+    /// </summary>
+    public static ProcessHandoff? TryLoad()
+    {
+        var path = FilePath;
+        if (!File.Exists(path)) return null;
+        try
+        {
+            var json = File.ReadAllText(path);
+            File.Delete(path);
+            return JsonSerializer.Deserialize<ProcessHandoff>(json);
+        }
+        catch
+        {
+            try { File.Delete(path); } catch { }
+            return null;
+        }
+    }
+}
+
+public sealed class HandoffEntry
+{
+    public string JobId { get; set; } = "";
+    public int ProcessId { get; set; }
+    public string WorkerName { get; set; } = "";
+    public string CommandType { get; set; } = "";
+    public string? ModelPath { get; set; }
+    public int TimeoutSeconds { get; set; }
+    public string StartedAt { get; set; } = "";
+}

--- a/revit-worker/app/Program.cs
+++ b/revit-worker/app/Program.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Windows.Forms;
 
 namespace RevitWorkerApp;
@@ -5,6 +6,12 @@ namespace RevitWorkerApp;
 static class Program
 {
     private const string MutexName = "RevitWorkerApp.SingleInstance";
+
+    public static string Version { get; } =
+        Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion?.Split('+')[0]
+        ?? "0.0.0";
 
     private static bool IsRuntimeAvailable()
     {
@@ -63,7 +70,7 @@ static class Program
                 return;
             }
 
-            AppLog.Info($"Application starting. Base: {AppContext.BaseDirectory} Log: {AppLog.LogFilePath}");
+            AppLog.Info($"RevitWorkerApp v{Version} starting. Base: {AppContext.BaseDirectory} Log: {AppLog.LogFilePath}");
 
             var context = new TrayApplicationContext();
             context.RunWithSettingsShown();

--- a/revit-worker/app/RedisMonitor.cs
+++ b/revit-worker/app/RedisMonitor.cs
@@ -3,15 +3,23 @@ using StackExchange.Redis;
 namespace RevitWorkerApp;
 
 /// <summary>
-/// Manages the Redis connection. Worker status is now tracked directly by
-/// WorkerProcessManager (no external PID monitoring needed).
+/// Manages the Redis connection with automatic reconnection.
 /// </summary>
 public sealed class RedisMonitor : IDisposable
 {
     private ConnectionMultiplexer? _connection;
     private readonly object _connectionLock = new();
+    private string? _lastUrl;
+    private Thread? _watchdog;
+    private volatile bool _disposed;
+    private volatile bool _autoReconnect;
+
+    private const int WatchdogIntervalMs = 10_000;
+    private const int ReconnectBackoffMs = 5_000;
+    private const int MaxReconnectBackoffMs = 60_000;
 
     public event EventHandler? ConnectionStateChanged;
+    public event EventHandler? Reconnected;
 
     public bool IsConnected => _connection?.IsConnected ?? false;
     public ConnectionMultiplexer? Connection => _connection;
@@ -22,25 +30,10 @@ public sealed class RedisMonitor : IDisposable
         lock (_connectionLock)
         {
             DisconnectInternal();
-            try
-            {
-                var opts = ParseRedisUrl(redisUrl);
-                opts.AbortOnConnectFail = false;
-                opts.ConnectTimeout = 5000;
-                AppLog.Info($"Connecting to Redis: {redisUrl}");
-                _connection = ConnectionMultiplexer.Connect(opts);
-                if (!_connection.IsConnected)
-                    throw new RedisConnectionException(ConnectionFailureType.UnableToConnect,
-                        "Could not reach Redis at " + redisUrl);
-                AppLog.Info($"Redis connected OK: {_connection.GetEndPoints().FirstOrDefault()}");
-                ConnectionStateChanged?.Invoke(this, EventArgs.Empty);
-            }
-            catch (Exception ex)
-            {
-                AppLog.Error($"Redis connect failed: {ex.Message}");
-                ConnectionStateChanged?.Invoke(this, EventArgs.Empty);
-                throw;
-            }
+            _lastUrl = redisUrl;
+            ConnectInternal(redisUrl);
+            _autoReconnect = true;
+            EnsureWatchdog();
         }
     }
 
@@ -48,8 +41,91 @@ public sealed class RedisMonitor : IDisposable
     {
         lock (_connectionLock)
         {
+            _autoReconnect = false;
             DisconnectInternal();
             ConnectionStateChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    public void EnableAutoReconnect(string redisUrl)
+    {
+        lock (_connectionLock)
+        {
+            _lastUrl = redisUrl;
+            _autoReconnect = true;
+            EnsureWatchdog();
+        }
+    }
+
+    private void ConnectInternal(string redisUrl)
+    {
+        var opts = ParseRedisUrl(redisUrl);
+        opts.AbortOnConnectFail = false;
+        opts.ConnectTimeout = 4000;
+        opts.SyncTimeout = 3000;
+        opts.AsyncTimeout = 3000;
+        opts.ReconnectRetryPolicy = new ExponentialRetry(ReconnectBackoffMs);
+        AppLog.Info($"Connecting to Redis: {redisUrl}");
+        _connection = ConnectionMultiplexer.Connect(opts);
+        if (!_connection.IsConnected)
+            throw new RedisConnectionException(ConnectionFailureType.UnableToConnect,
+                "Could not reach Redis at " + redisUrl);
+        AppLog.Info($"Redis connected OK: {_connection.GetEndPoints().FirstOrDefault()}");
+        ConnectionStateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void EnsureWatchdog()
+    {
+        if (_watchdog is { IsAlive: true }) return;
+        _watchdog = new Thread(WatchdogLoop) { IsBackground = true, Name = "RedisWatchdog" };
+        _watchdog.Start();
+    }
+
+    private void WatchdogLoop()
+    {
+        var backoff = ReconnectBackoffMs;
+
+        while (!_disposed)
+        {
+            Thread.Sleep(WatchdogIntervalMs);
+            if (_disposed || !_autoReconnect) break;
+
+            var url = _lastUrl;
+            if (string.IsNullOrEmpty(url)) continue;
+
+            var connected = false;
+            lock (_connectionLock)
+            {
+                connected = _connection?.IsConnected ?? false;
+            }
+
+            if (connected)
+            {
+                backoff = ReconnectBackoffMs;
+                continue;
+            }
+
+            AppLog.Warning($"Redis connection lost — reconnecting in {backoff / 1000}s...");
+            Thread.Sleep(backoff);
+            if (_disposed || !_autoReconnect) break;
+
+            try
+            {
+                lock (_connectionLock)
+                {
+                    DisconnectInternal();
+                    ConnectInternal(url);
+                }
+                backoff = ReconnectBackoffMs;
+                AppLog.Info("Redis reconnected successfully");
+                Reconnected?.Invoke(this, EventArgs.Empty);
+            }
+            catch (Exception ex)
+            {
+                AppLog.Error($"Redis reconnect failed: {ex.Message}");
+                ConnectionStateChanged?.Invoke(this, EventArgs.Empty);
+                backoff = Math.Min(backoff * 2, MaxReconnectBackoffMs);
+            }
         }
     }
 
@@ -61,6 +137,8 @@ public sealed class RedisMonitor : IDisposable
 
     public void Dispose()
     {
+        _disposed = true;
+        _autoReconnect = false;
         lock (_connectionLock)
         {
             DisconnectInternal();

--- a/revit-worker/app/RevitWorkerApp.csproj
+++ b/revit-worker/app/RevitWorkerApp.csproj
@@ -12,6 +12,7 @@
     <ApplicationIcon></ApplicationIcon>
     <AssemblyName>RevitWorkerApp</AssemblyName>
     <RootNamespace>RevitWorkerApp</RootNamespace>
+    <Version>1.4.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/revit-worker/app/RqJobConsumer.cs
+++ b/revit-worker/app/RqJobConsumer.cs
@@ -160,6 +160,7 @@ public sealed class RqJobConsumer
             new HashEntry("state", "idle"),
             new HashEntry("queues", _queueName),
             new HashEntry("current_job", ""),
+            new HashEntry("version", Program.Version),
         ]);
     }
 

--- a/revit-worker/app/TaskRunner.cs
+++ b/revit-worker/app/TaskRunner.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
+using System.Threading;
 
 namespace RevitWorkerApp;
 
@@ -11,12 +12,38 @@ namespace RevitWorkerApp;
 public static class TaskRunner
 {
     private static readonly HashSet<string> AllowedCommandTypes = new(StringComparer.OrdinalIgnoreCase)
-        { "pyrevit", "rtv", "powershell" };
+        { "pyrevit", "rtv", "powershell", "ddc" };
 
     private const int MaxOutputBytes = 64 * 1024;
 
-    public static async Task<Dictionary<string, object?>> RunRevitCommand(Dictionary<string, object?> jobData)
+    /// <summary>
+    /// Tracks active child processes by job ID for graceful-redeploy handoff.
+    /// </summary>
+    internal static System.Collections.Concurrent.ConcurrentDictionary<string, ActiveJob> ActiveProcesses { get; } = new();
+
+    /// <summary>
+    /// When true, cancellation callbacks log but do NOT kill child processes.
+    /// Set by WorkerProcessManager before a graceful shutdown so processes can be
+    /// handed off to the next instance.
+    /// </summary>
+    public static bool SuppressKillOnCancel { get; set; }
+
+    internal record ActiveJob(
+        int Pid,
+        string WorkerName,
+        string CommandType,
+        string? ModelPath,
+        int TimeoutSeconds,
+        DateTime StartedAt,
+        string? ScriptPath = null);
+
+    public static async Task<Dictionary<string, object?>> RunRevitCommand(
+        Dictionary<string, object?> jobData,
+        CancellationToken cancellationToken = default,
+        string? workerName = null)
     {
+        var tag = workerName != null ? $"[{workerName}]" : "[TaskRunner]";
+
         var jobId = GetString(jobData, "job_id");
         var commandType = GetString(jobData, "command_type")?.ToLowerInvariant() ?? "";
         var scriptPath = GetString(jobData, "script_path") ?? "";
@@ -25,6 +52,7 @@ public static class TaskRunner
         var batchFile = GetString(jobData, "batch_file");
         var arguments = GetStringList(jobData, "arguments");
         var timeoutSeconds = GetInt(jobData, "timeout_seconds", 3600);
+        var outputDir = GetString(jobData, "output_dir");
         var workingDirectory = GetString(jobData, "working_directory");
 
         var startedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ");
@@ -34,7 +62,7 @@ public static class TaskRunner
             return new Dictionary<string, object?>
             {
                 ["success"] = false,
-                ["error"] = $"Invalid command_type '{commandType}'. Must be one of: pyrevit, rtv, powershell",
+                ["error"] = $"Invalid command_type '{commandType}'. Must be one of: pyrevit, rtv, powershell, ddc",
                 ["exit_code"] = null,
                 ["started_at"] = startedAt,
                 ["finished_at"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),
@@ -44,7 +72,7 @@ public static class TaskRunner
         List<string> cmd;
         try
         {
-            cmd = BuildCommand(commandType, scriptPath, arguments, modelPath, revitVersion, batchFile, jobId);
+            cmd = BuildCommand(commandType, scriptPath, arguments, modelPath, revitVersion, batchFile, jobId, outputDir);
         }
         catch (Exception ex)
         {
@@ -61,6 +89,16 @@ public static class TaskRunner
         var cwd = !string.IsNullOrEmpty(workingDirectory) && Directory.Exists(workingDirectory)
             ? workingDirectory
             : null;
+        if (cwd == null && commandType.Equals("ddc", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrEmpty(modelPath))
+        {
+            try
+            {
+                var dir = Path.GetDirectoryName(modelPath);
+                if (!string.IsNullOrEmpty(dir) && Directory.Exists(dir))
+                    cwd = dir;
+            }
+            catch { /* ignore */ }
+        }
 
         Process? process = null;
         try
@@ -78,69 +116,132 @@ public static class TaskRunner
             if (cwd != null)
                 psi.WorkingDirectory = cwd;
 
-            AppLog.Info($"[TaskRunner] Launching: {psi.FileName} {string.Join(" ", cmd.Skip(1))}");
+            AppLog.Info($"{tag} Launching: {psi.FileName} {string.Join(" ", cmd.Skip(1))}");
             process = Process.Start(psi);
             if (process == null)
                 throw new InvalidOperationException("Failed to start process");
-            AppLog.Info($"[TaskRunner] Process started PID={process.Id}, waiting up to {timeoutSeconds}s...");
+            AppLog.Info($"{tag} Process started PID={process.Id}, waiting up to {timeoutSeconds}s...");
 
-            var stdoutTask = process.StandardOutput.ReadToEndAsync();
-            var stderrTask = process.StandardError.ReadToEndAsync();
-
-            var exited = process.WaitForExit(timeoutSeconds * 1000);
-            if (!exited)
+            if (jobId != null)
             {
-                try { process.Kill(entireProcessTree: true); } catch { }
-                return new Dictionary<string, object?>
+                ActiveProcesses[jobId] = new ActiveJob(
+                    process.Id,
+                    workerName ?? "",
+                    commandType,
+                    modelPath,
+                    timeoutSeconds,
+                    DateTime.UtcNow);
+            }
+
+            using (cancellationToken.Register(() =>
+                   {
+                       try
+                       {
+                           if (!process.HasExited)
+                           {
+                               if (SuppressKillOnCancel)
+                               {
+                                   AppLog.Info($"{tag} Graceful shutdown — leaving PID={process.Id} running for handoff");
+                               }
+                               else
+                               {
+                                   AppLog.Info($"{tag} Cancellation requested — killing process tree PID={process.Id}");
+                                   process.Kill(entireProcessTree: true);
+                               }
+                           }
+                       }
+                       catch (Exception ex)
+                       {
+                           AppLog.Warning($"{tag} Kill on cancel failed: {ex.Message}");
+                       }
+                   }))
+            {
+                var stdoutTask = process.StandardOutput.ReadToEndAsync();
+                var stderrTask = process.StandardError.ReadToEndAsync();
+
+                var exited = process.WaitForExit(timeoutSeconds * 1000);
+                if (!exited)
                 {
-                    ["success"] = false,
-                    ["error"] = $"Process timed out after {timeoutSeconds} seconds and was killed",
-                    ["exit_code"] = null,
+                    try { process.Kill(entireProcessTree: true); } catch { }
+                    return new Dictionary<string, object?>
+                    {
+                        ["success"] = false,
+                        ["error"] = $"Process timed out after {timeoutSeconds} seconds and was killed",
+                        ["exit_code"] = null,
+                        ["started_at"] = startedAt,
+                        ["finished_at"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),
+                    };
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    var finishedCancelled = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ");
+                    // Drain streams after kill so process can fully exit
+                    _ = stdoutTask.GetAwaiter().GetResult();
+                    _ = stderrTask.GetAwaiter().GetResult();
+                    return new Dictionary<string, object?>
+                    {
+                        ["success"] = false,
+                        ["cancelled"] = true,
+                        ["error"] = "Worker stopped -- process killed",
+                        ["exit_code"] = process.ExitCode,
+                        ["started_at"] = startedAt,
+                        ["finished_at"] = finishedCancelled,
+                    };
+                }
+
+                var rawStdout = stdoutTask.GetAwaiter().GetResult();
+                var stderr = Truncate(stderrTask.GetAwaiter().GetResult());
+                var exitCode = process.ExitCode;
+                var finishedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ");
+
+                // Parse sentinel data from stdout and merge into result
+                var baseResult = new Dictionary<string, object?>
+                {
+                    ["success"] = exitCode == 0,
+                    ["exit_code"] = exitCode,
                     ["started_at"] = startedAt,
-                    ["finished_at"] = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),
+                    ["finished_at"] = finishedAt,
+                    ["error"] = exitCode != 0 ? $"Process exited with code {exitCode}" : null,
                 };
+
+                var (parsedResult, cleanedStdout) = ParseSentinel(baseResult, rawStdout);
+
+                // Upload log files (use raw stdout/stderr locally for log discovery, but don't store them in the result)
+                var startedAtParsed = DateTime.Parse(startedAt);
+                var finishedAtParsed = DateTime.Parse(finishedAt);
+                var logFiles = FindLogFiles(commandType, startedAtParsed, finishedAtParsed, process?.Id ?? 0, jobId);
+
+                // DDC: capture stdout+stderr as a dedicated log file
+                if (commandType == "ddc" && (!string.IsNullOrEmpty(rawStdout) || !string.IsNullOrEmpty(stderr)))
+                {
+                    var ddcLogPath = WriteDdcLog(jobId, rawStdout, stderr);
+                    if (ddcLogPath != null)
+                        logFiles["ddc"] = ddcLogPath;
+                }
+
+                var stdoutLogs = FindLogsFromStdout(cleanedStdout, startedAtParsed, finishedAtParsed);
+                foreach (var kv in stdoutLogs)
+                    logFiles.TryAdd(kv.Key, kv.Value);
+
+                var settings = AppSettings.Load();
+                var workerLogTemp = logFiles.GetValueOrDefault("worker");
+                var uploadedLogPaths = await UploadLogs(jobId ?? "", settings.ApiGatewayUrl, settings.ApiKey, logFiles, tag);
+
+                // Clean up temp log extracts
+                if (workerLogTemp != null && workerLogTemp.StartsWith(Path.GetTempPath()))
+                    try { File.Delete(workerLogTemp); } catch { }
+                var ddcLogTemp = logFiles.GetValueOrDefault("ddc");
+                if (ddcLogTemp != null && ddcLogTemp.StartsWith(Path.GetTempPath()))
+                    try { File.Delete(ddcLogTemp); } catch { }
+
+                if (uploadedLogPaths.Count > 0)
+                {
+                    parsedResult["log_files"] = uploadedLogPaths;
+                }
+
+                return parsedResult;
             }
-
-            var rawStdout = stdoutTask.GetAwaiter().GetResult();
-            var stderr = Truncate(stderrTask.GetAwaiter().GetResult());
-            var exitCode = process.ExitCode;
-            var finishedAt = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ");
-
-            // Parse sentinel data from stdout and merge into result
-            var baseResult = new Dictionary<string, object?>
-            {
-                ["success"] = exitCode == 0,
-                ["exit_code"] = exitCode,
-                ["started_at"] = startedAt,
-                ["finished_at"] = finishedAt,
-                ["error"] = exitCode != 0 ? $"Process exited with code {exitCode}" : null,
-            };
-
-            var (parsedResult, cleanedStdout) = ParseSentinel(baseResult, rawStdout);
-
-            // Upload log files (use raw stdout/stderr locally for log discovery, but don't store them in the result)
-            var startedAtParsed = DateTime.Parse(startedAt);
-            var finishedAtParsed = DateTime.Parse(finishedAt);
-            var logFiles = FindLogFiles(commandType, startedAtParsed, finishedAtParsed, process?.Id ?? 0, jobId);
-
-            var stdoutLogs = FindLogsFromStdout(cleanedStdout, startedAtParsed, finishedAtParsed);
-            foreach (var kv in stdoutLogs)
-                logFiles.TryAdd(kv.Key, kv.Value);
-
-            var settings = AppSettings.Load();
-            var workerLogTemp = logFiles.GetValueOrDefault("worker");
-            var uploadedLogPaths = await UploadLogs(jobId ?? "", settings.ApiGatewayUrl, settings.ApiKey, logFiles);
-
-            // Clean up temp worker log extract
-            if (workerLogTemp != null && workerLogTemp.StartsWith(Path.GetTempPath()))
-                try { File.Delete(workerLogTemp); } catch { }
-
-            if (uploadedLogPaths.Count > 0)
-            {
-                parsedResult["log_files"] = uploadedLogPaths;
-            }
-
-            return parsedResult;
         }
         catch (System.ComponentModel.Win32Exception ex)
         {
@@ -166,6 +267,7 @@ public static class TaskRunner
         }
         finally
         {
+            if (jobId != null) ActiveProcesses.TryRemove(jobId, out _);
             process?.Dispose();
         }
     }
@@ -227,8 +329,26 @@ public static class TaskRunner
             JsonValueKind.True => true,
             JsonValueKind.False => false,
             JsonValueKind.Null => null,
+            JsonValueKind.Array => JsonElementToList(el),
+            JsonValueKind.Object => JsonElementToDict(el),
             _ => el.GetRawText()
         };
+    }
+
+    private static List<object?> JsonElementToList(JsonElement el)
+    {
+        var list = new List<object?>();
+        foreach (var item in el.EnumerateArray())
+            list.Add(JsonElementToObject(item));
+        return list;
+    }
+
+    private static Dictionary<string, object?> JsonElementToDict(JsonElement el)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var prop in el.EnumerateObject())
+            dict[prop.Name] = JsonElementToObject(prop.Value);
+        return dict;
     }
 
     /// <summary>
@@ -430,6 +550,32 @@ public static class TaskRunner
         }
     }
 
+    private static string? WriteDdcLog(string? jobId, string stdout, string stderr)
+    {
+        try
+        {
+            var sb = new StringBuilder();
+            if (!string.IsNullOrEmpty(stdout))
+            {
+                sb.AppendLine("=== DDC stdout ===");
+                sb.AppendLine(stdout);
+            }
+            if (!string.IsNullOrEmpty(stderr))
+            {
+                sb.AppendLine("=== DDC stderr ===");
+                sb.AppendLine(stderr);
+            }
+            if (sb.Length == 0) return null;
+            var tempPath = Path.Combine(Path.GetTempPath(), $"ddc-{jobId ?? "unknown"}.log");
+            File.WriteAllText(tempPath, sb.ToString());
+            return tempPath;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static readonly System.Text.RegularExpressions.Regex QuotedFilePathRegex =
         new(@"""([A-Za-z]:\\[^""]+\.(log|txt))""", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
 
@@ -525,13 +671,13 @@ public static class TaskRunner
     /// <summary>
     /// Uploads log files to the API gateway and returns their paths.
     /// </summary>
-    internal static async Task<List<string>> UploadLogs(string jobId, string? apiGatewayUrl, string? apiKey, Dictionary<string, string?> logFiles)
+    internal static async Task<List<string>> UploadLogs(string jobId, string? apiGatewayUrl, string? apiKey, Dictionary<string, string?> logFiles, string tag = "[TaskRunner]")
     {
         var uploadedPaths = new List<string>();
 
         if (string.IsNullOrEmpty(apiGatewayUrl) || string.IsNullOrEmpty(apiKey))
         {
-            AppLog.Info("[TaskRunner] Skipping log upload - API gateway URL or key not configured");
+            AppLog.Info($"{tag} Skipping log upload - API gateway URL or key not configured");
             return uploadedPaths;
         }
 
@@ -566,17 +712,17 @@ public static class TaskRunner
                     if (responseData != null && responseData.TryGetValue("file_path", out var pathObj))
                     {
                         uploadedPaths.Add(pathObj?.ToString() ?? "");
-                        AppLog.Info($"[TaskRunner] Uploaded {logType} log to {pathObj}");
+                        AppLog.Info($"{tag} Uploaded {logType} log to {pathObj}");
                     }
                 }
                 else
                 {
-                    AppLog.Warning($"[TaskRunner] Failed to upload {logType} log: {response.StatusCode}");
+                    AppLog.Warning($"{tag} Failed to upload {logType} log: {response.StatusCode}");
                 }
             }
             catch (Exception ex)
             {
-                AppLog.Warning($"[TaskRunner] Error uploading {logType} log: {ex.Message}");
+                AppLog.Warning($"{tag} Error uploading {logType} log: {ex.Message}");
             }
         }
 
@@ -584,7 +730,7 @@ public static class TaskRunner
     }
 
     private static List<string> BuildCommand(string commandType, string scriptPath,
-        List<string> arguments, string? modelPath, string? revitVersion, string? batchFile, string? jobId)
+        List<string> arguments, string? modelPath, string? revitVersion, string? batchFile, string? jobId, string? outputDir = null)
     {
         var cmd = new List<string>();
         switch (commandType)
@@ -605,12 +751,75 @@ public static class TaskRunner
                 cmd.AddRange(["powershell.exe", "-ExecutionPolicy", "Bypass", "-NonInteractive", "-File", scriptPath]);
                 if (!string.IsNullOrEmpty(modelPath)) cmd.AddRange(["-ModelPath", modelPath]);
                 if (!string.IsNullOrEmpty(revitVersion)) cmd.AddRange(["-RevitVersion", revitVersion]);
+                if (!string.IsNullOrEmpty(jobId)) cmd.AddRange(["-JobId", jobId]);
+                cmd.AddRange(arguments);
+                break;
+            case "ddc":
+                if (string.IsNullOrWhiteSpace(modelPath))
+                    throw new ArgumentException("model_path is required for command_type ddc");
+                var ddcExe = ResolveDdcExporterPath(scriptPath);
+                var ifcFileName = System.Text.RegularExpressions.Regex.Replace(
+                    Path.GetFileName(modelPath.Trim()), @"\.rvt$", ".ifc",
+                    System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+                var outputIfc = !string.IsNullOrWhiteSpace(outputDir)
+                    ? Path.Combine(outputDir.Trim(), ifcFileName)
+                    : Path.Combine(Path.GetDirectoryName(modelPath.Trim()) ?? ".", ifcFileName);
+                var ifcDir = Path.GetDirectoryName(outputIfc);
+                if (!string.IsNullOrWhiteSpace(ifcDir) && !Directory.Exists(ifcDir))
+                    Directory.CreateDirectory(ifcDir);
+                cmd.Add(ddcExe);
+                cmd.Add(modelPath);
+                cmd.Add(outputIfc);
+                cmd.AddRange([
+                    "mode=custom",
+                    "FileVersion=\"ifc4rv\"",
+                    "FileType=\"ifc\"",
+                    "LevelOfDetail=\"medium\"",
+                    "IfcCommonPropSets=\"y\"",
+                    "BimRvPropSets=\"y\"",
+                    "BaseQuantities=\"y\"",
+                    "ProjOrigin=\"currentshared\"",
+                ]);
                 cmd.AddRange(arguments);
                 break;
             default:
                 throw new ArgumentException($"Unknown command_type: {commandType}");
         }
         return cmd;
+    }
+
+    /// <summary>
+    /// DDC / RVT→IFC standalone converter: optional script_path override, then DDC_EXPORTER_PATH,
+    /// then first existing default path (INTERAXO install vs legacy C:\DDC\RvtExporter.exe).
+    /// </summary>
+    private static string ResolveDdcExporterPath(string? scriptPath)
+    {
+        if (!string.IsNullOrWhiteSpace(scriptPath))
+            return scriptPath.Trim();
+
+        var env = Environment.GetEnvironmentVariable("DDC_EXPORTER_PATH");
+        if (!string.IsNullOrWhiteSpace(env))
+            return env.Trim();
+
+        var defaults = new[]
+        {
+            @"B:\INTERAXO\DDC\DDC_REVIT2IFC_CONVERTER\RVT2IFCconverter.exe",
+            @"C:\DDC\RvtExporter.exe",
+        };
+        foreach (var p in defaults)
+        {
+            try
+            {
+                if (File.Exists(p))
+                    return p;
+            }
+            catch
+            {
+                /* ignore path probe errors */
+            }
+        }
+
+        return defaults[0];
     }
 
     private static string Truncate(string text)

--- a/revit-worker/app/TrayApplicationContext.cs
+++ b/revit-worker/app/TrayApplicationContext.cs
@@ -27,7 +27,7 @@ public sealed class TrayApplicationContext : ApplicationContext
         _notifyIcon = new NotifyIcon
         {
             Icon = _iconRed,
-            Text = "Revit Worker (disconnected)",
+            Text = $"Revit Worker v{Program.Version} (disconnected)",
             Visible = true
         };
         _uiContext = SynchronizationContext.Current;
@@ -62,7 +62,10 @@ public sealed class TrayApplicationContext : ApplicationContext
 
         _processManager.WorkerStatusChanged += OnWorkerStatusChanged;
         _processManager.JobAccepted += OnJobAccepted;
+        _processManager.AdoptedJobStarted += (_, e) => PostToUI(() => _mainForm?.OnAdoptedJobStarted(e));
+        _processManager.AdoptedJobFinished += (_, e) => PostToUI(() => _mainForm?.OnAdoptedJobFinished(e));
         _redisMonitor.ConnectionStateChanged += (_, _) => PostToUI(UpdateIconAndTooltip);
+        _redisMonitor.Reconnected += (_, _) => PostToUI(OnReconnected);
 
         Application.ApplicationExit += (_, _) =>
         {
@@ -74,6 +77,83 @@ public sealed class TrayApplicationContext : ApplicationContext
             _iconGreen?.Dispose();
             _iconOrange?.Dispose();
         };
+
+        StartGracefulStopListener();
+    }
+
+    /// <summary>
+    /// Waits on a named EventWaitHandle signalled by the deploy script.
+    /// When signalled: writes a process handoff file, cancels workers (without killing
+    /// child processes), then exits cleanly.
+    /// </summary>
+    private void StartGracefulStopListener()
+    {
+        var thread = new System.Threading.Thread(() =>
+        {
+            try
+            {
+                using var evt = new System.Threading.EventWaitHandle(
+                    false,
+                    System.Threading.EventResetMode.ManualReset,
+                    "RevitWorkerApp_GracefulStop");
+
+                evt.WaitOne();
+
+                AppLog.Info("[GracefulStop] Deploy signal received — writing handoff and exiting");
+
+                // Snapshot active processes BEFORE cancelling tokens
+                var handoff = new ProcessHandoff();
+                foreach (var kv in TaskRunner.ActiveProcesses)
+                {
+                    handoff.ActiveJobs.Add(new HandoffEntry
+                    {
+                        JobId      = kv.Key,
+                        ProcessId  = kv.Value.Pid,
+                        WorkerName = kv.Value.WorkerName,
+                        CommandType = kv.Value.CommandType,
+                        ModelPath  = kv.Value.ModelPath,
+                        TimeoutSeconds = kv.Value.TimeoutSeconds,
+                        StartedAt  = kv.Value.StartedAt.ToString("yyyy-MM-ddTHH:mm:ss.ffffffZ"),
+                    });
+                }
+
+                if (handoff.ActiveJobs.Count > 0)
+                {
+                    try
+                    {
+                        handoff.Save();
+                        AppLog.Info($"[GracefulStop] Handoff written: {handoff.ActiveJobs.Count} job(s) → {ProcessHandoff.FilePath}");
+                    }
+                    catch (Exception ex)
+                    {
+                        AppLog.Warning($"[GracefulStop] Could not write handoff: {ex.Message}");
+                    }
+                }
+                else
+                {
+                    AppLog.Info("[GracefulStop] No active jobs — no handoff file written");
+                }
+
+                // Cancel worker loops without killing child processes
+                _processManager.GracefulShutdown = true;
+                _processManager.StopAll();
+
+                // Exit on the UI thread
+                PostToUI(() =>
+                {
+                    try { ExitThread(); } catch { }
+                });
+            }
+            catch (Exception ex)
+            {
+                AppLog.Warning($"[GracefulStop] Listener error: {ex.Message}");
+            }
+        })
+        {
+            IsBackground = true,
+            Name = "GracefulStopListener"
+        };
+        thread.Start();
     }
 
     public WorkerProcessManager ProcessManager => _processManager;
@@ -83,6 +163,71 @@ public sealed class TrayApplicationContext : ApplicationContext
     {
         EnsureMainForm();
         _mainForm!.Show();
+        AutoConnect();
+    }
+
+    /// <summary>
+    /// Automatically connect to Redis and start workers using saved settings.
+    /// </summary>
+    private void AutoConnect()
+    {
+        var settings = AppSettings.Load();
+        if (string.IsNullOrWhiteSpace(settings.RedisUrl)) return;
+
+        AppLog.Info($"Auto-connect: redis={settings.RedisUrl} queue={settings.QueueNames} workers={settings.ClampedWorkerCount} api={settings.ApiGatewayUrl ?? "(none)"}");
+        try { settings.Save(); } catch { }
+
+        Task.Run(() =>
+        {
+            try
+            {
+                _redisMonitor.Connect(settings.RedisUrl);
+                _processManager.Configure(settings.RedisUrl, settings.QueueNames, settings.JobStartDelaySeconds);
+                _processManager.SetConnection(_redisMonitor.Connection!);
+
+                var count = settings.ClampedWorkerCount;
+                for (var i = 0; i < count; i++)
+                    _processManager.AddWorker();
+
+                AppLog.Info($"Auto-connected OK, started {count} worker(s)");
+                _processManager.AdoptHandoff();
+                PostToUI(() => _mainForm?.OnAutoConnected());
+            }
+            catch (Exception ex)
+            {
+                AppLog.Warning($"Auto-connect failed: {ex.Message} \u2014 will retry in background");
+                _redisMonitor.EnableAutoReconnect(settings.RedisUrl);
+            }
+        });
+    }
+
+    private void OnReconnected()
+    {
+        if (_paused) return;
+
+        Task.Run(() =>
+        {
+            var settings = AppSettings.Load();
+            var count = settings.ClampedWorkerCount;
+            AppLog.Info($"Connection restored \u2014 starting {count} worker(s)...");
+
+            try
+            {
+                _processManager.StopAll();
+                _processManager.Configure(settings.RedisUrl, settings.QueueNames, settings.JobStartDelaySeconds);
+                _processManager.SetConnection(_redisMonitor.Connection!);
+
+                for (var i = 0; i < count; i++)
+                    _processManager.AddWorker();
+
+                AppLog.Info($"Reconnect: started {count} worker(s)");
+            }
+            catch (Exception ex)
+            {
+                AppLog.Error($"Reconnect: failed to restart workers \u2014 {ex.Message}");
+            }
+            PostToUI(UpdateIconAndTooltip);
+        });
     }
 
     public bool IsPaused => _paused;
@@ -134,7 +279,7 @@ public sealed class TrayApplicationContext : ApplicationContext
         PostToUI(() =>
         {
             UpdateIconAndTooltip();
-            _mainForm?.UpdateWorkerRow(e.WorkerName, e.State, e.CurrentJobId);
+            _mainForm?.UpdateWorkerRow(e.WorkerName, e.State, e.CurrentJobId, e.ModelPath);
         });
     }
 
@@ -157,9 +302,13 @@ public sealed class TrayApplicationContext : ApplicationContext
     private void PostToUI(Action action)
     {
         if (_uiContext != null)
-            _uiContext.Post(_ => action(), null);
-        else
-            action();
+        {
+            _uiContext.Post(_ => { try { action(); } catch (ObjectDisposedException) { } }, null);
+        }
+        else if (_mainForm is { IsDisposed: false, IsHandleCreated: true })
+        {
+            try { _mainForm.BeginInvoke(action); } catch { }
+        }
     }
 
     private void UpdateIconAndTooltip()
@@ -168,20 +317,21 @@ public sealed class TrayApplicationContext : ApplicationContext
         {
             IconGenerator.TrayState state;
             string text;
+            var ver = $"v{Program.Version}";
             if (_paused || !_redisMonitor.IsConnected)
             {
                 state = IconGenerator.TrayState.Red;
-                text = _paused ? "Revit Worker (paused)" : "Revit Worker (disconnected)";
+                text = _paused ? $"Revit Worker {ver} (paused)" : $"Revit Worker {ver} (disconnected)";
             }
             else if (_anyWorkerBusy)
             {
                 state = IconGenerator.TrayState.Orange;
-                text = "Revit Worker (working)";
+                text = $"Revit Worker {ver} (working)";
             }
             else
             {
                 state = IconGenerator.TrayState.Green;
-                text = "Revit Worker (active)";
+                text = $"Revit Worker {ver} (active)";
             }
 
             _notifyIcon.Icon = state switch

--- a/revit-worker/app/WorkerProcessManager.cs
+++ b/revit-worker/app/WorkerProcessManager.cs
@@ -26,6 +26,8 @@ public sealed class WorkerProcessManager : IDisposable
     public event EventHandler<JobAcceptedEventArgs>? JobAccepted;
     public event EventHandler<WorkerErrorEventArgs>? WorkerError;
     public event EventHandler? WorkerCountChanged;
+    public event EventHandler<AdoptedJobEventArgs>? AdoptedJobStarted;
+    public event EventHandler<AdoptedJobEventArgs>? AdoptedJobFinished;
 
     public int CurrentCount
     {
@@ -101,6 +103,12 @@ public sealed class WorkerProcessManager : IDisposable
         WorkerCountChanged?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// When true, StopAll cancels worker loops but does not kill child processes.
+    /// Set before a graceful redeploy so in-flight processes can be handed off.
+    /// </summary>
+    public bool GracefulShutdown { get; set; }
+
     public void StopAll()
     {
         lock (_lock) StopAllInternal();
@@ -109,6 +117,8 @@ public sealed class WorkerProcessManager : IDisposable
 
     private void StopAllInternal()
     {
+        if (GracefulShutdown)
+            TaskRunner.SuppressKillOnCancel = true;
         foreach (var kv in _workers)
             kv.Value.Cts.Cancel();
         _workers.Clear();
@@ -127,6 +137,217 @@ public sealed class WorkerProcessManager : IDisposable
     public IReadOnlyList<string> GetWorkerNames()
     {
         lock (_lock) return _workers.Keys.ToList();
+    }
+
+    /// <summary>
+    /// Called on startup: loads handoff.json written by the previous instance,
+    /// reattaches to any still-running child processes, monitors them to completion,
+    /// and reports results to Redis.
+    /// </summary>
+    public void AdoptHandoff()
+    {
+        var handoff = ProcessHandoff.TryLoad();
+        if (handoff == null || handoff.ActiveJobs.Count == 0) return;
+
+        AppLog.Info($"[Handoff] Found {handoff.ActiveJobs.Count} job(s) from previous instance (written {handoff.WrittenAt})");
+
+        var conn = _connection;
+        if (conn == null || !conn.IsConnected)
+        {
+            AppLog.Warning("[Handoff] No Redis connection yet — cannot adopt jobs");
+            return;
+        }
+
+        var db = conn.GetDatabase();
+        var consumer = new RqJobConsumer(db, _queueName);
+
+        foreach (var entry in handoff.ActiveJobs)
+        {
+            var capturedEntry = entry;
+            Task.Run(() => MonitorAdoptedProcess(capturedEntry, consumer));
+        }
+    }
+
+    private void MonitorAdoptedProcess(HandoffEntry entry, RqJobConsumer consumer)
+    {
+        var tag = $"[adopted][{entry.WorkerName}]";
+        AppLog.Info($"{tag} Job {entry.JobId}: reattaching to PID={entry.ProcessId}");
+
+        if (!IsProcessAlive(entry.ProcessId))
+        {
+            AppLog.Info($"{tag} Job {entry.JobId}: PID={entry.ProcessId} already gone - checking sidecar");
+            FinalizeAdoptedJob(entry, consumer, tag, exitCode: null);
+            return;
+        }
+
+        var adoptedAt = DateTime.UtcNow;
+        AdoptedJobStarted?.Invoke(this, new AdoptedJobEventArgs(entry.JobId, entry.WorkerName, entry.ProcessId, adoptedAt) { ModelPath = entry.ModelPath });
+
+        var startedAt = DateTime.TryParse(entry.StartedAt, out var sa) ? sa : DateTime.UtcNow;
+        var deadline = startedAt.AddSeconds(entry.TimeoutSeconds);
+
+        try
+        {
+            while (IsProcessAlive(entry.ProcessId))
+            {
+                if (DateTime.UtcNow > deadline)
+                {
+                    AppLog.Warning($"{tag} Job {entry.JobId}: timeout reached - killing PID={entry.ProcessId}");
+                    try
+                    {
+                        using var p = System.Diagnostics.Process.GetProcessById(entry.ProcessId);
+                        p.Kill(entireProcessTree: true);
+                    }
+                    catch { }
+                    consumer.MarkFailed(entry.JobId, "Worker redeployed - adopted job timed out and was killed");
+                    AdoptedJobFinished?.Invoke(this, new AdoptedJobEventArgs(entry.JobId, entry.WorkerName, entry.ProcessId, adoptedAt) { Success = false });
+                    return;
+                }
+
+                try { consumer.Heartbeat(entry.JobId); } catch { }
+                System.Threading.Thread.Sleep(15_000);
+            }
+
+            AppLog.Info($"{tag} Job {entry.JobId}: PID={entry.ProcessId} exited");
+            FinalizeAdoptedJob(entry, consumer, tag, exitCode: null, adoptedAt);
+        }
+        catch (Exception ex)
+        {
+            AppLog.Warning($"{tag} Job {entry.JobId}: monitor error - {ex.Message}");
+            consumer.MarkFailed(entry.JobId, $"Worker redeployed - monitor error: {ex.Message}");
+            AdoptedJobFinished?.Invoke(this, new AdoptedJobEventArgs(entry.JobId, entry.WorkerName, entry.ProcessId, adoptedAt) { Success = false });
+        }
+    }
+
+    /// <summary>
+    /// Reliable process-alive check that doesn't require a pre-existing handle.
+    /// GetProcessById + HasExited is unreliable on attached handles; re-opening
+    /// the process fresh each time avoids "not started by this object" errors.
+    /// </summary>
+    private static bool IsProcessAlive(int pid)
+    {
+        try
+        {
+            using var p = System.Diagnostics.Process.GetProcessById(pid);
+            return !p.HasExited;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private void FinalizeAdoptedJob(HandoffEntry entry, RqJobConsumer consumer, string tag, int? exitCode, DateTime? adoptedAt = null)
+    {
+        var sidecarResult = TryReadSidecar(entry.ModelPath, entry.JobId);
+        bool success;
+
+        if (sidecarResult != null)
+        {
+            var hasError = sidecarResult.TryGetValue("error", out var errVal) && errVal != null;
+            var hasSuccess = sidecarResult.TryGetValue("success", out var s);
+            success = hasSuccess ? s is true : !hasError;
+
+            if (success)
+            {
+                consumer.MarkFinished(entry.JobId, sidecarResult);
+                AppLog.Info($"{tag} Job {entry.JobId}: [FINISHED] (from sidecar)");
+            }
+            else
+            {
+                var err = hasError ? errVal?.ToString() : null;
+                consumer.MarkFailed(entry.JobId, err ?? "Job failed (from sidecar)");
+                AppLog.Warning($"{tag} Job {entry.JobId}: [FAILED] (from sidecar) {err}");
+            }
+        }
+        else if (exitCode == 0)
+        {
+            success = true;
+            var result = new Dictionary<string, object?>
+            {
+                ["success"] = true,
+                ["exit_code"] = exitCode,
+                ["note"] = "Result from adopted process (no sidecar found)",
+            };
+            consumer.MarkFinished(entry.JobId, result);
+            AppLog.Info($"{tag} Job {entry.JobId}: [FINISHED] exit_code=0, no sidecar");
+        }
+        else
+        {
+            success = false;
+            var msg = exitCode.HasValue
+                ? $"Worker redeployed, process exited with code {exitCode}, no result sidecar found"
+                : "Worker redeployed, process exited, no result sidecar found";
+            consumer.MarkFailed(entry.JobId, msg);
+            AppLog.Warning($"{tag} Job {entry.JobId}: [FAILED] {msg}");
+        }
+
+        AdoptedJobFinished?.Invoke(this, new AdoptedJobEventArgs(
+            entry.JobId, entry.WorkerName, entry.ProcessId, adoptedAt ?? DateTime.UtcNow) { Success = success });
+    }
+
+    /// <summary>
+    /// Searches for a sidecar result file written by the job script.
+    /// Looks for *.rbp_rw_result.json and *.rw_result.json patterns near the model path.
+    /// </summary>
+    private static Dictionary<string, object?>? TryReadSidecar(string? modelPath, string jobId)
+    {
+        var candidates = new List<string>();
+
+        if (!string.IsNullOrEmpty(modelPath))
+        {
+            var dir = Path.GetDirectoryName(modelPath) ?? "";
+            var stem = Path.GetFileNameWithoutExtension(modelPath);
+            // Sidecar next to the model (written by detach_repath_rbp.py)
+            candidates.Add(Path.Combine(dir, stem + ".rbp_rw_result.json"));
+            candidates.Add(Path.Combine(dir, stem + ".rw_result.json"));
+            // Detached variant (_detached suffix)
+            var detachedStem = stem.EndsWith("_detached") ? stem : stem + "_detached";
+            candidates.Add(Path.Combine(dir, detachedStem + ".rbp_rw_result.json"));
+        }
+
+        // Also check next to the exe
+        candidates.Add(Path.Combine(AppContext.BaseDirectory, jobId + ".rbp_rw_result.json"));
+        candidates.Add(Path.Combine(AppContext.BaseDirectory, jobId + ".rw_result.json"));
+
+        // Check %TEMP%\rbp_detach_repath where Run-RBPDetachRepath.ps1 writes the pre-flight sidecar
+        if (!string.IsNullOrEmpty(modelPath))
+        {
+            var stem2 = Path.GetFileNameWithoutExtension(modelPath);
+            var rbpTempDir = Path.Combine(Path.GetTempPath(), "rbp_detach_repath");
+            candidates.Add(Path.Combine(rbpTempDir, stem2 + ".rbp_rw_result.json"));
+        }
+
+        foreach (var path in candidates)
+        {
+            AppLog.Info($"[Sidecar] checking: {path}");
+            if (!File.Exists(path)) continue;
+            try
+            {
+                var json = File.ReadAllText(path);
+                AppLog.Info($"[Sidecar] found: {path} ({json.Length} bytes)");
+                var doc = System.Text.Json.JsonDocument.Parse(json);
+                var dict = new Dictionary<string, object?>();
+                foreach (var prop in doc.RootElement.EnumerateObject())
+                {
+                    dict[prop.Name] = prop.Value.ValueKind switch
+                    {
+                        System.Text.Json.JsonValueKind.True  => (object?)true,
+                        System.Text.Json.JsonValueKind.False => false,
+                        System.Text.Json.JsonValueKind.Null  => null,
+                        System.Text.Json.JsonValueKind.Number => prop.Value.TryGetInt64(out var i) ? i : prop.Value.GetDouble(),
+                        _ => prop.Value.GetString(),
+                    };
+                }
+                return dict;
+            }
+            catch (Exception ex)
+            {
+                AppLog.Warning($"[Sidecar] failed to read {path}: {ex.Message}");
+            }
+        }
+        AppLog.Warning($"[Sidecar] no sidecar found for job {jobId} (checked {candidates.Count} paths)");
+        return null;
     }
 
     private void CleanupDeadWorkers()
@@ -173,6 +394,7 @@ public sealed class WorkerProcessManager : IDisposable
                     continue;
                 }
 
+                var modelPath = jobData.TryGetValue("model_path", out var mp) ? mp?.ToString() : null;
                 AppLog.Info($"[{workerName}] Job {jobId}: unpickled OK, command_type={jobData.GetValueOrDefault("command_type")}");
 
                 // Start gate: stagger job starts so two workers never launch at the same moment
@@ -194,34 +416,55 @@ public sealed class WorkerProcessManager : IDisposable
                     while (remainingMs > 0 && !token.IsCancellationRequested)
                     {
                         var sec = (remainingMs + 999) / 1000;
-                        SetState(workerName, false, jobId);
-                        RaiseStatus(workerName, $"start-delay ({sec}s)", jobId);
+                        SetState(workerName, false, jobId, modelPath);
+                        RaiseStatus(workerName, $"start-delay ({sec}s)", jobId, modelPath);
                         var sleepMs = Math.Min(1000, remainingMs);
                         Thread.Sleep(sleepMs);
                         remainingMs -= sleepMs;
                     }
-                    if (token.IsCancellationRequested) continue;
+                    if (token.IsCancellationRequested)
+                    {
+                        consumer.MarkFailed(jobId, "Worker stopped before job could start");
+                        AppLog.Warning($"[{workerName}] Job {jobId}: [CANCELLED] stopped during start-delay");
+                        continue;
+                    }
                 }
 
                 consumer.MarkStarted(jobId, workerName);
                 AppLog.Info($"[{workerName}] Job {jobId}: [STARTED]");
                 consumer.SetWorkerState(workerName, "busy", jobId);
-                SetState(workerName, true, jobId);
-                RaiseStatus(workerName, "busy", jobId);
+                SetState(workerName, true, jobId, modelPath);
+                RaiseStatus(workerName, "busy", jobId, modelPath);
                 JobAccepted?.Invoke(this, new JobAcceptedEventArgs(jobId));
 
                 AppLog.Info($"[{workerName}] Job {jobId}: executing command...");
                 jobData["job_id"] = jobId;
-                var resultTask = Task.Run(() => TaskRunner.RunRevitCommand(jobData));
+                var resultTask = Task.Run(() => TaskRunner.RunRevitCommand(jobData, token, workerName));
                 while (!resultTask.IsCompleted)
                 {
                     if (resultTask.Wait(TimeSpan.FromSeconds(15)))
+                        break;
+                    if (token.IsCancellationRequested)
                         break;
                     try { consumer.Heartbeat(jobId); consumer.SetWorkerState(workerName, "busy", jobId); }
                     catch { }
                 }
                 // RunRevitCommand is async; Task.Run(Func<Task<T>>) returns Task<T>, so one GetResult() gives the dictionary
                 var result = resultTask.GetAwaiter().GetResult();
+
+                var cancelled = result.TryGetValue("cancelled", out var cancelVal)
+                    && cancelVal is bool cancelledBool
+                    && cancelledBool;
+                if (cancelled)
+                {
+                    var msg = result.TryGetValue("error", out var ce) ? ce?.ToString() ?? "Worker stopped during execution" : "Worker stopped during execution";
+                    consumer.MarkFailed(jobId, msg);
+                    AppLog.Warning($"[{workerName}] Job {jobId}: [CANCELLED] {msg}");
+                    consumer.SetWorkerState(workerName, "idle");
+                    SetState(workerName, false, null);
+                    RaiseStatus(workerName, "idle", null);
+                    continue;
+                }
 
                 var success = result.TryGetValue("success", out var s) && s is true;
                 var exitCode = result.TryGetValue("exit_code", out var ec) ? ec : null;
@@ -250,6 +493,7 @@ public sealed class WorkerProcessManager : IDisposable
             catch (Exception ex)
             {
                 if (token.IsCancellationRequested) break;
+                AppLog.Error($"[{workerName}] Unhandled: {ex.Message}");
                 WorkerError?.Invoke(this, new WorkerErrorEventArgs($"[{workerName}] {ex.Message}"));
                 Thread.Sleep(2000);
             }
@@ -260,20 +504,20 @@ public sealed class WorkerProcessManager : IDisposable
         RaiseStatus(workerName, "stopped", null);
     }
 
-    private void SetState(string workerName, bool busy, string? jobId)
+    private void SetState(string workerName, bool busy, string? jobId, string? modelPath = null)
     {
         lock (_lock)
         {
-            _workerStates[workerName] = new WorkerState(workerName, busy, jobId);
+            _workerStates[workerName] = new WorkerState(workerName, busy, jobId, modelPath);
         }
     }
 
-    private void RaiseStatus(string workerName, string state, string? jobId)
+    private void RaiseStatus(string workerName, string state, string? jobId, string? modelPath = null)
     {
-        WorkerStatusChanged?.Invoke(this, new WorkerStatusEventArgs(workerName, state, jobId));
+        WorkerStatusChanged?.Invoke(this, new WorkerStatusEventArgs(workerName, state, jobId, modelPath));
     }
 
-    private record WorkerState(string Name, bool IsBusy, string? JobId);
+    private record WorkerState(string Name, bool IsBusy, string? JobId, string? ModelPath = null);
 }
 
 public sealed class WorkerStatusEventArgs : EventArgs
@@ -281,11 +525,13 @@ public sealed class WorkerStatusEventArgs : EventArgs
     public string WorkerName { get; }
     public string State { get; }
     public string? CurrentJobId { get; }
-    public WorkerStatusEventArgs(string workerName, string state, string? currentJobId)
+    public string? ModelPath { get; }
+    public WorkerStatusEventArgs(string workerName, string state, string? currentJobId, string? modelPath = null)
     {
         WorkerName = workerName;
         State = state;
         CurrentJobId = currentJobId;
+        ModelPath = modelPath;
     }
 }
 
@@ -299,4 +545,22 @@ public sealed class WorkerErrorEventArgs : EventArgs
 {
     public string Message { get; }
     public WorkerErrorEventArgs(string message) => Message = message;
+}
+
+public sealed class AdoptedJobEventArgs : EventArgs
+{
+    public string JobId { get; }
+    public string OriginalWorkerName { get; }
+    public int Pid { get; }
+    public DateTime AdoptedAt { get; }
+    public string? ModelPath { get; init; }
+    public bool Success { get; init; }
+
+    public AdoptedJobEventArgs(string jobId, string originalWorkerName, int pid, DateTime adoptedAt)
+    {
+        JobId = jobId;
+        OriginalWorkerName = originalWorkerName;
+        Pid = pid;
+        AdoptedAt = adoptedAt;
+    }
 }

--- a/revit-worker/tests/ParseSentinelTests.cs
+++ b/revit-worker/tests/ParseSentinelTests.cs
@@ -111,4 +111,20 @@ Done.";
         Assert.Equal("sentinel_value", result["custom_field"]); // Overridden by sentinel
         Assert.Equal("new_value", result["new_field"]); // New field added
     }
+
+    [Fact]
+    public void ParseSentinel_WithJsonArraysAndObjects_PreservesStructure()
+    {
+        var baseResult = new Dictionary<string, object?> { ["success"] = true };
+        var stdout = @"RW_RESULT:{""warnings_total"":0,""families_names"":[""A"",""Project Base Point""],""coord_family_instances"":{""project_base_point"":[],""survey_point"":[]}}";
+
+        var (result, _) = TaskRunner.ParseSentinel(baseResult, stdout);
+
+        Assert.Equal(0, result["warnings_total"]);
+        Assert.True(result["families_names"] is List<object?>);
+        var names = (List<object?>)result["families_names"]!;
+        Assert.Equal(2, names.Count);
+        Assert.Equal("Project Base Point", names[1]?.ToString());
+        Assert.True(result["coord_family_instances"] is Dictionary<string, object?>);
+    }
 }

--- a/shared/classes.py
+++ b/shared/classes.py
@@ -561,17 +561,36 @@ class RevitCommandType(str, Enum):
     PYREVIT = "pyrevit"
     RTV = "rtv"
     POWERSHELL = "powershell"
+    DDC = "ddc"
 
 class RevitExecuteRequest(BaseModel):
     """Request to execute a Revit/PyRevit command on the Windows worker."""
-    command_type: RevitCommandType = Field(..., description="Type of command: pyrevit, rtv, or powershell")
-    script_path: str = Field(..., description="Path to the script, executable, or PS1 wrapper on the Windows machine")
+    command_type: RevitCommandType = Field(
+        ...,
+        description="Type of command: pyrevit, rtv, powershell, or ddc (standalone RVT→IFC via DDC)",
+    )
+    script_path: Optional[str] = Field(
+        default=None,
+        description="Path to the script, executable, or PS1 wrapper. Not required for ddc (uses DDC_EXPORTER_PATH or default installer paths).",
+    )
     model_path: Optional[str] = Field(default=None, description="Path to the .rvt model (passed as positional arg for pyrevit)")
     revit_version: Optional[str] = Field(default=None, description="Revit year to launch, e.g. '2025'. Adds --revit=YYYY for pyrevit")
     batch_file: Optional[str] = Field(default=None, description="RTV batch file path (.rbxml). Passed as -BatchFile arg to the RTV wrapper script")
     arguments: Optional[List[str]] = Field(default=[], description="Additional command-line arguments")
     timeout_seconds: int = Field(default=3600, ge=10, le=86400, description="Max execution time in seconds")
+    output_dir: Optional[str] = Field(default=None, description="Output directory for DDC IFC export (if not set, writes next to the .rvt)")
     working_directory: Optional[str] = Field(default=None, description="Working directory (local or UNC path)")
+    meta: Optional[dict] = Field(default=None, description="Arbitrary metadata attached to the RQ job (visible in dashboard)")
+
+    @model_validator(mode="after")
+    def validate_paths_for_command_type(self):
+        if self.command_type == RevitCommandType.DDC:
+            if not self.model_path or not str(self.model_path).strip():
+                raise ValueError("model_path is required for command_type ddc")
+        else:
+            if not self.script_path or not str(self.script_path).strip():
+                raise ValueError("script_path is required unless command_type is ddc")
+        return self
 
     class Config:
         json_schema_extra = {
@@ -588,6 +607,12 @@ class RevitExecuteRequest(BaseModel):
                     "script_path": "\\\\bim-host.example.internal\\Client\\INTERAXO\\Project-Phase\\Discipline\\Batch\\Run-RTVXporterBatch.ps1",
                     "batch_file": "\\\\bim-host.example.internal\\Client\\INTERAXO\\Project-Phase\\Discipline\\Batch\\sample.rbxml",
                     "timeout_seconds": 7200
+                },
+                {
+                    "command_type": "ddc",
+                    "model_path": "C:\\Models\\project.rvt",
+                    "output_dir": "C:\\Output\\ifc",
+                    "timeout_seconds": 3600
                 }
             ]
         }

--- a/shared/classes.py
+++ b/shared/classes.py
@@ -561,36 +561,18 @@ class RevitCommandType(str, Enum):
     PYREVIT = "pyrevit"
     RTV = "rtv"
     POWERSHELL = "powershell"
-    DDC = "ddc"
 
 class RevitExecuteRequest(BaseModel):
     """Request to execute a Revit/PyRevit command on the Windows worker."""
-    command_type: RevitCommandType = Field(
-        ...,
-        description="Type of command: pyrevit, rtv, powershell, or ddc (standalone RVT→IFC via DDC)",
-    )
-    script_path: Optional[str] = Field(
-        default=None,
-        description="Path to the script, executable, or PS1 wrapper. Not required for ddc (uses DDC_EXPORTER_PATH or default installer paths).",
-    )
+    command_type: RevitCommandType = Field(..., description="Type of command: pyrevit, rtv, or powershell")
+    script_path: str = Field(..., description="Path to the script, executable, or PS1 wrapper on the Windows machine")
     model_path: Optional[str] = Field(default=None, description="Path to the .rvt model (passed as positional arg for pyrevit)")
     revit_version: Optional[str] = Field(default=None, description="Revit year to launch, e.g. '2025'. Adds --revit=YYYY for pyrevit")
     batch_file: Optional[str] = Field(default=None, description="RTV batch file path (.rbxml). Passed as -BatchFile arg to the RTV wrapper script")
     arguments: Optional[List[str]] = Field(default=[], description="Additional command-line arguments")
     timeout_seconds: int = Field(default=3600, ge=10, le=86400, description="Max execution time in seconds")
-    output_dir: Optional[str] = Field(default=None, description="Output directory for DDC IFC export (if not set, writes next to the .rvt)")
     working_directory: Optional[str] = Field(default=None, description="Working directory (local or UNC path)")
     meta: Optional[dict] = Field(default=None, description="Arbitrary metadata attached to the RQ job (visible in dashboard)")
-
-    @model_validator(mode="after")
-    def validate_paths_for_command_type(self):
-        if self.command_type == RevitCommandType.DDC:
-            if not self.model_path or not str(self.model_path).strip():
-                raise ValueError("model_path is required for command_type ddc")
-        else:
-            if not self.script_path or not str(self.script_path).strip():
-                raise ValueError("script_path is required unless command_type is ddc")
-        return self
 
     class Config:
         json_schema_extra = {
@@ -607,12 +589,6 @@ class RevitExecuteRequest(BaseModel):
                     "script_path": "\\\\bim-host.example.internal\\Client\\INTERAXO\\Project-Phase\\Discipline\\Batch\\Run-RTVXporterBatch.ps1",
                     "batch_file": "\\\\bim-host.example.internal\\Client\\INTERAXO\\Project-Phase\\Discipline\\Batch\\sample.rbxml",
                     "timeout_seconds": 7200
-                },
-                {
-                    "command_type": "ddc",
-                    "model_path": "C:\\Models\\project.rvt",
-                    "output_dir": "C:\\Output\\ifc",
-                    "timeout_seconds": 3600
                 }
             ]
         }


### PR DESCRIPTION
## Summary
- Ports the Forgejo `specialfastigheter/ifcpipeline` Revit worker (**v1.4.5**, not 1.45.0) onto GitHub `ifcpipeline`.
- Adds graceful redeploy handoff, Redis auto-reconnect, DDC `command_type`, richer UI, and RQ `meta` (`model_name` / `commandtype`) on `POST /revit/execute`.
- **Does not** copy Specialfastigheter site config: no hardcoded API key, worker count stays 1, Redis/gateway examples stay `bim-host-ubnt`.

## Test plan
- [ ] `dotnet` tests in `revit-worker/tests` (Linux Docker SDK image)
- [ ] Window title / tray tooltip show `v1.4.5`
- [ ] `POST /revit/execute` with `command_type: ddc` requires `model_path` and does not require `script_path`
- [ ] Existing `pyrevit` / `rtv` / `powershell` jobs still enqueue
- [ ] Rebuild `api-gateway` after merge so the live stack picks up the request schema


Made with [Cursor](https://cursor.com)