### PR TITLE
Add Revit Batch Processor example jobs

### DIFF
--- a/revit-worker/README.md
+++ b/revit-worker/README.md
@@ -45,6 +45,13 @@ revit-worker/
 │   ├── RevitWorkerApp.csproj     # .NET 8 WinForms project (win-x64)
 │   ├── build.sh                  # Tests + publish (cross-compile from Linux)
 │   └── build-publish-only.sh     # Publish only
+├── examples/
+│   ├── README.md                 # Enqueue payloads for the sample RBP jobs
+│   ├── Run-RBPDetachRepath.ps1   # Detach + audit + SaveAs
+│   ├── Run-RBPModelAudit.ps1     # Audit only
+│   ├── Run-RBPIfcExport.ps1      # IFC4 Reference View export
+│   ├── detach_repath*.py / model_audit.py / ifc_export_rbp.py
+│   └── RevitBackupCleanup.ps1
 ├── tests/
 │   ├── ParseSentinelTests.cs     # RW_RESULT sentinel parsing tests
 │   ├── LogFinderTests.cs         # Log file discovery tests
@@ -69,6 +76,7 @@ revit-worker/
 | Revit (e.g. 2024/2025) | Installed on the Windows machine |
 | PyRevit | Required for `pyrevit` command type jobs |
 | RTV Tools (Xporter Pro) | Required for `rtv` command type jobs |
+| Revit Batch Processor | Required for the `examples/` RBP jobs (`BatchRvt.exe`) |
 | Network access to Redis | Machine must reach Redis on the pipeline host (default port 6379) |
 
 ## Installation & Configuration
@@ -264,6 +272,18 @@ Runs a PowerShell script on the Windows machine (e.g. file copy, model preparati
 | `working_directory` | `C:\Temp` |
 
 **Flow:** Manual trigger → Config node → POST `/revit/execute` → Wait 5 s → GET `/jobs/{id}/status` → loop until `finished` or `failed`.
+
+### RBP example scripts (`revit-worker/examples/`)
+
+PowerShell launchers that call Revit Batch Processor. Copy `examples/` onto the Windows host and point `script_path` at the `.ps1`. See [`examples/README.md`](examples/README.md).
+
+| Job | `script_path` | Extra `arguments` |
+|-----|---------------|-------------------|
+| Detach + audit + SaveAs | `...\examples\Run-RBPDetachRepath.ps1` | — |
+| Model audit only | `...\examples\Run-RBPModelAudit.ps1` | — |
+| IFC4 RV export | `...\examples\Run-RBPIfcExport.ps1` | `["-ExportDir", "C:\\Output\\ifc"]` |
+
+`command_type` is `powershell`; set `model_path` and `revit_version` as usual.
 
 ### Interaxo Upload Triggers
 

--- a/revit-worker/examples/README.md
+++ b/revit-worker/examples/README.md
@@ -1,0 +1,77 @@
+# Revit worker example scripts
+
+Generic **Revit Batch Processor (RBP)** jobs for `POST /revit/execute` with
+`command_type: powershell`. Copy this `examples/` folder onto the Windows
+machine next to `RevitWorkerApp.exe` (or keep the paths in `script_path`).
+
+Requires [Revit Batch Processor](https://github.com/nmclean/RevitBatchProcessor)
+(`%LOCALAPPDATA%\RevitBatchProcessor\BatchRvt.exe`) and a matching Revit year.
+
+IronPython task scripts are 2.7-compatible (no f-strings). Results go to stdout
+as `RW_RESULT:{json}` and to a `.rbp_rw_result.json` sidecar (used if the
+worker is redeployed mid-job).
+
+| Script | What it does |
+|--------|----------------|
+| `Run-RBPDetachRepath.ps1` | Detach the central, collect model audit, save `{stem}_detached.rvt` |
+| `Run-RBPModelAudit.ps1` | Same open path, audit only (no SaveAs) |
+| `Run-RBPIfcExport.ps1` | Find or create a 3D view, export IFC4 Reference View |
+
+The worker forwards `-ModelPath`, `-RevitVersion`, and `-JobId`. Extra flags go
+in `arguments`.
+
+## Detach + audit + save
+
+```json
+{
+  "command_type": "powershell",
+  "script_path": "C:\\revit-worker\\examples\\Run-RBPDetachRepath.ps1",
+  "model_path": "C:\\Models\\project.rvt",
+  "revit_version": "2025",
+  "timeout_seconds": 3600
+}
+```
+
+## Model audit only
+
+```json
+{
+  "command_type": "powershell",
+  "script_path": "C:\\revit-worker\\examples\\Run-RBPModelAudit.ps1",
+  "model_path": "C:\\Models\\project.rvt",
+  "revit_version": "2025",
+  "timeout_seconds": 1800
+}
+```
+
+`Run-RBPModelAudit.ps1` is a thin wrapper that runs detach/repath with
+`-AnalyticsOnly`.
+
+## IFC export
+
+```json
+{
+  "command_type": "powershell",
+  "script_path": "C:\\revit-worker\\examples\\Run-RBPIfcExport.ps1",
+  "model_path": "C:\\Models\\project.rvt",
+  "revit_version": "2025",
+  "timeout_seconds": 3600,
+  "arguments": ["-ExportDir", "C:\\Output\\ifc"]
+}
+```
+
+Optional arguments: `-Filename` (stem without `.ifc`), or set env
+`RBP_PSET_FILE` to a user-defined property-set definition file.
+
+## Files
+
+| File | Role |
+|------|------|
+| `Run-RBPDetachRepath.ps1` | Launches BatchRvt `--detach` with `detach_repath_rbp.py` |
+| `Run-RBPModelAudit.ps1` | Calls the detach launcher with `-AnalyticsOnly` |
+| `Run-RBPIfcExport.ps1` | Launches BatchRvt `--detach` with `ifc_export_rbp.py` |
+| `detach_repath_rbp.py` | RBP entry: active document → `process_open_document` |
+| `detach_repath.py` | Audit + optional SaveAs as a new central |
+| `model_audit.py` | Warning / view / sheet / link / level counts |
+| `ifc_export_rbp.py` | 3D view + `doc.Export` IFC4 RV |
+| `RevitBackupCleanup.ps1` | Deletes `*.0001.rvt` incrementals after BatchRvt |

--- a/revit-worker/examples/RevitBackupCleanup.ps1
+++ b/revit-worker/examples/RevitBackupCleanup.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+  Remove Revit incremental backup .rvt files next to a model (e.g. Model.0001.rvt).
+#>
+function Remove-RevitIncrementalBackupRvt {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)][string]$ModelPath,
+        [Parameter(Mandatory = $false)][scriptblock]$LogMessage = $null
+    )
+
+    function Write-CleanupLog([string]$Message) {
+        if ($LogMessage) { & $LogMessage $Message } else { Write-Host $Message }
+    }
+
+    $dir = [System.IO.Path]::GetDirectoryName($ModelPath)
+    if ([string]::IsNullOrWhiteSpace($dir) -or -not (Test-Path -LiteralPath $dir)) { return }
+    $mainName = [System.IO.Path]::GetFileName($ModelPath)
+
+    Get-ChildItem -LiteralPath $dir -Filter *.rvt -File -ErrorAction SilentlyContinue | ForEach-Object {
+        if ($_.Name -notmatch '\.\d{4}\.rvt$') { return }
+        if ($_.Name -ieq $mainName) { return }
+        try {
+            Remove-Item -LiteralPath $_.FullName -Force
+            Write-CleanupLog "Removed incremental backup $($_.Name)"
+        } catch {
+            Write-CleanupLog "WARN: could not remove $($_.Name): $_"
+        }
+    }
+}

--- a/revit-worker/examples/Run-RBPDetachRepath.ps1
+++ b/revit-worker/examples/Run-RBPDetachRepath.ps1
@@ -1,0 +1,158 @@
+<#
+.SYNOPSIS
+    RBP launcher: detach a workshared model, run model audit, optionally SaveAs.
+
+.DESCRIPTION
+    Runs Revit Batch Processor with detach_repath_rbp.py. BatchRvt opens the model
+    (--detach). Python does not call OpenDocumentFile.
+
+.PARAMETER ModelPath
+    Path to the .rvt file (local or UNC).
+
+.PARAMETER RevitYear
+    Revit version year for RBP (default 2025). Alias: RevitVersion.
+
+.PARAMETER JobId
+    Optional job id for logs and sidecar names.
+
+.PARAMETER AnalyticsOnly
+    Collect model audit only; skip SaveAs.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ModelPath,
+
+    [Parameter(Mandatory = $false)]
+    [Alias("RevitVersion")]
+    [int]$RevitYear = 2025,
+
+    [Parameter(Mandatory = $false)]
+    [string]$JobId = "",
+
+    [Parameter(Mandatory = $false)]
+    [switch]$AnalyticsOnly
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $JobId) { $JobId = [guid]::NewGuid().ToString('N').Substring(0, 8) }
+
+$env:IFC_PIPELINE_JOB_ID = $JobId
+
+$ScriptDir = $PSScriptRoot
+$TempDir = Join-Path $env:TEMP "rbp_detach_repath"
+if (-not (Test-Path $TempDir)) { New-Item -ItemType Directory -Path $TempDir -Force | Out-Null }
+
+$DiagLog = Join-Path $TempDir "rbp_diag_$JobId.log"
+
+function Diag($msg) {
+    $ts = Get-Date -Format "HH:mm:ss.fff"
+    $line = "[$ts] $msg"
+    $line | Out-File -Append -FilePath $DiagLog -Encoding UTF8
+}
+
+Diag "=== RBP DetachRepath Start ==="
+Diag "Model: $ModelPath JobId: $JobId RevitYear: $RevitYear AnalyticsOnly: $AnalyticsOnly"
+
+$BatchRvtExe = Join-Path $env:LOCALAPPDATA "RevitBatchProcessor\BatchRvt.exe"
+if (-not (Test-Path $BatchRvtExe)) {
+    Diag "ERROR: BatchRvt.exe not found at $BatchRvtExe"
+    $fallback = @{ error = "BatchRvt.exe not found at $BatchRvtExe"; host = "rbp" } | ConvertTo-Json -Compress
+    Write-Output "RW_RESULT:$fallback"
+    exit 1
+}
+
+$TaskScript = Join-Path $ScriptDir "detach_repath_rbp.py"
+if (-not (Test-Path -LiteralPath $TaskScript)) {
+    Diag "ERROR: detach_repath_rbp.py missing under $ScriptDir"
+    $fallback = @{ error = "detach_repath_rbp.py not found next to the launcher"; host = "rbp" } | ConvertTo-Json -Compress
+    Write-Output "RW_RESULT:$fallback"
+    exit 1
+}
+
+$FileListPath = Join-Path $TempDir "filelist_$JobId.txt"
+[System.IO.File]::WriteAllText($FileListPath, $ModelPath, (New-Object System.Text.UTF8Encoding $false))
+
+$LogFolder = Join-Path $TempDir "logs_$JobId"
+if (-not (Test-Path $LogFolder)) { New-Item -ItemType Directory -Path $LogFolder -Force | Out-Null }
+
+if ($AnalyticsOnly) { $env:ANALYTICS_ONLY = "1" }
+else { Remove-Item Env:\ANALYTICS_ONLY -ErrorAction SilentlyContinue }
+
+$modelBaseName = [System.IO.Path]::GetFileNameWithoutExtension($ModelPath)
+$preflightSidecar = Join-Path $TempDir "$modelBaseName.rbp_rw_result.json"
+$env:RBP_SIDECAR_PATH = $preflightSidecar
+$preflightJson = @{
+    error = "RBP task did not complete"
+    host = "rbp"
+    preflight = $true
+    model_path = $ModelPath
+    job_id = $JobId
+} | ConvertTo-Json -Compress
+[System.IO.File]::WriteAllText($preflightSidecar, $preflightJson, (New-Object System.Text.UTF8Encoding $false))
+
+$rbpOutputLog = Join-Path $TempDir "batchrvt_stdout_$JobId.log"
+$rbpArgs = @(
+    "--task_script", $TaskScript,
+    "--file_list", $FileListPath,
+    "--detach",
+    "--worksets", "open_all",
+    "--revit_version", $RevitYear,
+    "--log_folder", $LogFolder
+)
+
+$rbpExitCode = 0
+try {
+    Diag "BatchRvt args: $($rbpArgs -join ' ')"
+    & $BatchRvtExe @rbpArgs > $rbpOutputLog 2>&1
+    $rbpExitCode = $LASTEXITCODE
+} catch {
+    Diag "ERROR running BatchRvt: $_"
+    $rbpExitCode = 99
+}
+
+Diag "BatchRvt exit: $rbpExitCode"
+
+$revitCleanup = Join-Path $ScriptDir "RevitBackupCleanup.ps1"
+if (Test-Path -LiteralPath $revitCleanup) {
+    . $revitCleanup
+    Remove-RevitIncrementalBackupRvt -ModelPath $ModelPath -LogMessage { param($Message) Diag $Message }
+}
+
+Write-Output "Logs: $LogFolder\"
+Write-Output """$DiagLog"""
+if (Test-Path $rbpOutputLog) { Write-Output """$rbpOutputLog""" }
+
+$modelDir = [System.IO.Path]::GetDirectoryName($ModelPath)
+$sidecarName = "$modelBaseName.rbp_rw_result.json"
+$detachedBaseName = ($modelBaseName -replace '_detached$', '') + "_detached"
+$candidatePaths = @(
+    (Join-Path $modelDir $sidecarName),
+    (Join-Path $modelDir "$detachedBaseName.rbp_rw_result.json"),
+    $preflightSidecar
+)
+
+$rwFile = $null
+foreach ($p in $candidatePaths) {
+    if (Test-Path $p) { $rwFile = $p; Diag "Found sidecar: $p"; break }
+}
+
+if ($rwFile) {
+    $rwJson = Get-Content -LiteralPath $rwFile -Raw -Encoding utf8 -ErrorAction SilentlyContinue
+    if ($rwJson) { Write-Output "RW_RESULT:$rwJson" }
+} else {
+    $fallback = @{
+        error = "No RBP RW_RESULT sidecar found"
+        host = "rbp"
+        rbp_exit_code = $rbpExitCode
+    } | ConvertTo-Json -Compress
+    Write-Output "RW_RESULT:$fallback"
+}
+
+Remove-Item Env:\RBP_SIDECAR_PATH -ErrorAction SilentlyContinue
+Remove-Item Env:\ANALYTICS_ONLY -ErrorAction SilentlyContinue
+Remove-Item $FileListPath -Force -ErrorAction SilentlyContinue
+
+Diag "=== RBP DetachRepath End ==="
+exit $rbpExitCode

--- a/revit-worker/examples/Run-RBPIfcExport.ps1
+++ b/revit-worker/examples/Run-RBPIfcExport.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+    RBP IFC exporter: open detached, ensure a 3D view, export IFC4 Reference View.
+
+.PARAMETER ModelPath
+    Path to the .rvt model.
+
+.PARAMETER ExportDir
+    Directory for the .ifc file.
+
+.PARAMETER Filename
+    Output stem without .ifc (default: model name, minus _detached).
+
+.PARAMETER RevitYear
+    Revit version year (default 2025). Alias: RevitVersion.
+
+.PARAMETER JobId
+    Job id for logs and sidecar names.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ModelPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ExportDir,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Filename = "",
+
+    [Parameter(Mandatory = $false)]
+    [Alias("RevitVersion")]
+    [int]$RevitYear = 2025,
+
+    [Parameter(Mandatory = $false)]
+    [string]$JobId = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not $JobId) { $JobId = [guid]::NewGuid().ToString('N').Substring(0, 8) }
+
+if (-not $Filename) {
+    $Filename = [System.IO.Path]::GetFileNameWithoutExtension($ModelPath)
+    $Filename = $Filename -replace '_detached$', ''
+}
+$Filename = [System.IO.Path]::GetFileName($Filename)
+if ($Filename -match '\.') { $Filename = [System.IO.Path]::GetFileNameWithoutExtension($Filename) }
+
+$ScriptDir = $PSScriptRoot
+$TempDir = Join-Path $env:TEMP "rbp_ifc_export"
+if (-not (Test-Path $TempDir)) { New-Item -ItemType Directory -Path $TempDir -Force | Out-Null }
+
+$DiagLog = Join-Path $TempDir "rbp_diag_$JobId.log"
+
+function Diag($msg) {
+    $ts = Get-Date -Format "HH:mm:ss.fff"
+    $line = "[$ts] $msg"
+    $line | Out-File -Append -FilePath $DiagLog -Encoding UTF8
+}
+
+Diag "=== RBP IFC export Start ==="
+Diag "Model: $ModelPath ExportDir: $ExportDir Filename: $Filename JobId: $JobId"
+
+$BatchRvtExe = Join-Path $env:LOCALAPPDATA "RevitBatchProcessor\BatchRvt.exe"
+if (-not (Test-Path $BatchRvtExe)) {
+    Diag "ERROR: BatchRvt.exe not found at $BatchRvtExe"
+    $fallback = @{ ifc_exported = $false; view_created = $false; error = "BatchRvt.exe not found at $BatchRvtExe" } | ConvertTo-Json -Compress
+    Write-Output "RW_RESULT:$fallback"
+    exit 1
+}
+
+$TaskScript = Join-Path $ScriptDir "ifc_export_rbp.py"
+if (-not (Test-Path -LiteralPath $TaskScript)) {
+    Diag "ERROR: ifc_export_rbp.py missing under $ScriptDir"
+    $fallback = @{ ifc_exported = $false; view_created = $false; error = "ifc_export_rbp.py not found next to the launcher" } | ConvertTo-Json -Compress
+    Write-Output "RW_RESULT:$fallback"
+    exit 1
+}
+
+$FileListPath = Join-Path $TempDir "filelist_$JobId.txt"
+[System.IO.File]::WriteAllText($FileListPath, $ModelPath, (New-Object System.Text.UTF8Encoding $false))
+
+$LogFolder = Join-Path $TempDir "logs_$JobId"
+if (-not (Test-Path $LogFolder)) { New-Item -ItemType Directory -Path $LogFolder -Force | Out-Null }
+
+$env:RBP_EXPORT_DIR = $ExportDir
+$env:RBP_IFC_FILENAME = $Filename
+$env:RBP_JOB_ID = $JobId
+
+$modelBaseName = [System.IO.Path]::GetFileNameWithoutExtension($ModelPath)
+$preflightSidecar = Join-Path $TempDir "$modelBaseName.rbp_rw_result.json"
+$env:RBP_SIDECAR_PATH = $preflightSidecar
+$preflightJson = @{
+    ifc_exported = $false
+    view_created = $false
+    error = "RBP task script did not execute"
+    model_path = $ModelPath
+    job_id = $JobId
+    preflight = $true
+} | ConvertTo-Json -Compress
+[System.IO.File]::WriteAllText($preflightSidecar, $preflightJson, (New-Object System.Text.UTF8Encoding $false))
+
+$rbpOutputLog = Join-Path $TempDir "batchrvt_stdout_$JobId.log"
+$rbpExitCode = 0
+try {
+    & $BatchRvtExe --task_script $TaskScript --file_list $FileListPath --detach --worksets open_all --revit_version $RevitYear --log_folder $LogFolder > $rbpOutputLog 2>&1
+    $rbpExitCode = $LASTEXITCODE
+} catch {
+    Diag "ERROR running BatchRvt: $_"
+    $rbpExitCode = 99
+}
+
+Diag "BatchRvt exit: $rbpExitCode"
+
+$revitCleanup = Join-Path $ScriptDir "RevitBackupCleanup.ps1"
+if (Test-Path -LiteralPath $revitCleanup) {
+    . $revitCleanup
+    Remove-RevitIncrementalBackupRvt -ModelPath $ModelPath -LogMessage { param($Message) Diag $Message }
+}
+
+Write-Output "Logs: $LogFolder\"
+Write-Output """$DiagLog"""
+if (Test-Path $rbpOutputLog) { Write-Output """$rbpOutputLog""" }
+
+$modelDir = [System.IO.Path]::GetDirectoryName($ModelPath)
+$sidecarName = "$modelBaseName.rbp_rw_result.json"
+$detachedBaseName = ($modelBaseName -replace '_detached$', '') + "_detached"
+$candidatePaths = @(
+    (Join-Path $modelDir $sidecarName),
+    (Join-Path $modelDir "$detachedBaseName.rbp_rw_result.json"),
+    (Join-Path $ExportDir $sidecarName),
+    $preflightSidecar
+)
+
+$rwFile = $null
+foreach ($p in $candidatePaths) {
+    if (Test-Path $p) { $rwFile = $p; Diag "Found sidecar: $p"; break }
+}
+
+if ($rwFile) {
+    $rwJson = Get-Content -LiteralPath $rwFile -Raw -Encoding utf8 -ErrorAction SilentlyContinue
+    if ($rwJson) { Write-Output "RW_RESULT:$rwJson" }
+} else {
+    $fallback = @{
+        ifc_exported = $false
+        view_created = $false
+        error = "No RW_RESULT sidecar file produced"
+        rbp_exit_code = $rbpExitCode
+    } | ConvertTo-Json -Compress
+    Write-Output "RW_RESULT:$fallback"
+}
+
+Remove-Item Env:\RBP_EXPORT_DIR -ErrorAction SilentlyContinue
+Remove-Item Env:\RBP_IFC_FILENAME -ErrorAction SilentlyContinue
+Remove-Item Env:\RBP_JOB_ID -ErrorAction SilentlyContinue
+Remove-Item Env:\RBP_SIDECAR_PATH -ErrorAction SilentlyContinue
+Remove-Item $FileListPath -Force -ErrorAction SilentlyContinue
+
+Diag "=== RBP IFC export End ==="
+exit $rbpExitCode

--- a/revit-worker/examples/Run-RBPModelAudit.ps1
+++ b/revit-worker/examples/Run-RBPModelAudit.ps1
@@ -1,0 +1,26 @@
+<#
+.SYNOPSIS
+    RBP model audit only (no SaveAs).
+
+.DESCRIPTION
+    Same BatchRvt detach open as Run-RBPDetachRepath.ps1, with -AnalyticsOnly.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ModelPath,
+
+    [Parameter(Mandatory = $false)]
+    [Alias("RevitVersion")]
+    [int]$RevitYear = 2025,
+
+    [Parameter(Mandatory = $false)]
+    [string]$JobId = ""
+)
+
+& (Join-Path $PSScriptRoot "Run-RBPDetachRepath.ps1") `
+    -ModelPath $ModelPath `
+    -RevitYear $RevitYear `
+    -JobId $JobId `
+    -AnalyticsOnly
+exit $LASTEXITCODE

--- a/revit-worker/examples/detach_repath.py
+++ b/revit-worker/examples/detach_repath.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""Detach / audit / SaveAs pipeline used by detach_repath_rbp.py (IronPython 2.7).
+
+RBP opens the document with --detach. This module collects model_audit stats and,
+unless ANALYTICS_ONLY is set, saves a new central as {stem}_detached.rvt.
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import traceback
+
+import clr
+
+clr.AddReference("RevitAPI")
+from Autodesk.Revit.DB import (  # noqa: E402
+    ModelPathUtils,
+    SaveAsOptions,
+    WorksharingSaveAsOptions,
+)
+
+from model_audit import collect_analytics  # noqa: E402
+
+
+class Logger(object):
+    def __init__(self):
+        self.lines = []
+        self.log_file = ""
+
+    def _emit(self, level, msg):
+        line = "[{}] {}".format(level, msg)
+        self.lines.append(line)
+        print(line)
+
+    def info(self, msg):
+        self._emit("INFO", msg)
+
+    def warning(self, msg):
+        self._emit("WARN", msg)
+
+    def error(self, msg):
+        self._emit("ERROR", msg)
+
+    def debug(self, msg):
+        self._emit("DEBUG", msg)
+
+
+def _normalize_model_path_for_revit(path):
+    if not path:
+        return ""
+    return os.path.abspath(path.replace("/", "\\"))
+
+
+def _write_rw_result(data, extra_paths):
+    payload = json.dumps(data, ensure_ascii=True)
+    print("RW_RESULT:" + payload)
+    for path in extra_paths or []:
+        if not path:
+            continue
+        try:
+            parent = os.path.dirname(path)
+            if parent and not os.path.isdir(parent):
+                os.makedirs(parent)
+            with open(path, "w") as fh:
+                fh.write(payload)
+        except Exception:
+            pass
+
+
+def process_open_document(
+    doc,
+    model_path_abs,
+    analytics_only,
+    log,
+    is_workshared_file,
+    doc_is_workshared,
+    open_mode,
+    model_path_obj,
+    extra_rw_result_paths=None,
+    audit_on_open=False,
+):
+    """Run audit, optionally SaveAs a detached central, write sidecar(s)."""
+    rw = {
+        "success": True,
+        "host": "rbp",
+        "open_mode": open_mode,
+        "analytics_only": bool(analytics_only),
+        "audit_on_open": bool(audit_on_open),
+        "model_path": model_path_abs,
+        "workshared_file": bool(is_workshared_file),
+        "doc_workshared": bool(doc_is_workshared),
+        "saved_path": None,
+    }
+
+    extra_paths = list(extra_rw_result_paths or [])
+    try:
+        log.info("Collecting model audit")
+        rw.update(collect_analytics(doc, model_path_abs) or {})
+
+        if analytics_only:
+            log.info("Analytics-only: skipping SaveAs")
+            _write_rw_result(rw, extra_paths)
+            return True
+
+        stem = os.path.splitext(os.path.basename(model_path_abs))[0]
+        if stem.endswith("_detached"):
+            out_name = stem + ".rvt"
+        else:
+            out_name = stem + "_detached.rvt"
+        out_path = os.path.join(os.path.dirname(model_path_abs), out_name)
+        rw["saved_path"] = out_path
+
+        save_options = SaveAsOptions()
+        save_options.OverwriteExistingFile = True
+        if doc_is_workshared:
+            ws = WorksharingSaveAsOptions()
+            ws.SaveAsCentral = True
+            save_options.SetWorksharingOptions(ws)
+
+        dest = ModelPathUtils.ConvertUserVisiblePathToModelPath(out_path)
+        log.info("SaveAs {}".format(out_path))
+        doc.SaveAs(dest, save_options)
+        rw["saved"] = True
+        _write_rw_result(rw, extra_paths)
+        return True
+    except Exception as ex:
+        log.error(traceback.format_exc())
+        rw["success"] = False
+        rw["error"] = str(ex)
+        _write_rw_result(rw, extra_paths)
+        return False

--- a/revit-worker/examples/detach_repath_rbp.py
+++ b/revit-worker/examples/detach_repath_rbp.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""RBP task script: detach_repath pipeline.
+
+BatchRvt opens the model (--detach). Environment: ANALYTICS_ONLY, RBP_SIDECAR_PATH.
+Launcher: Run-RBPDetachRepath.ps1 / Run-RBPModelAudit.ps1.
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+
+import clr
+
+clr.AddReference("RevitAPI")
+from Autodesk.Revit.DB import BasicFileInfo, ModelPathUtils  # noqa: E402
+
+import revit_script_util
+from revit_script_util import Output
+
+try:
+    _script_dir = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    _script_dir = os.getcwd()
+if _script_dir not in sys.path:
+    sys.path.insert(0, _script_dir)
+
+from detach_repath import (  # noqa: E402
+    Logger,
+    process_open_document,
+    _normalize_model_path_for_revit,
+)
+
+log = Logger()
+log.info("detach_repath_rbp (module load)")
+
+doc = revit_script_util.GetScriptDocument()
+raw_path = revit_script_util.GetRevitFilePath() or ""
+model_path_abs = _normalize_model_path_for_revit(raw_path)
+log.info("Model path: {}".format(model_path_abs))
+
+analytics_only = os.environ.get("ANALYTICS_ONLY", "").lower() in ("1", "true", "yes")
+
+try:
+    fi = BasicFileInfo.Extract(model_path_abs)
+    is_workshared_file = fi.IsWorkshared
+except Exception as ex:
+    log.warning("BasicFileInfo.Extract failed: {}".format(ex))
+    is_workshared_file = False
+
+try:
+    doc_is_workshared = doc.IsWorkshared
+except Exception:
+    doc_is_workshared = is_workshared_file
+
+model_path_obj = ModelPathUtils.ConvertUserVisiblePathToModelPath(model_path_abs)
+
+model_name = os.path.splitext(os.path.basename(model_path_abs))[0]
+extra_paths = []
+_sc = os.environ.get("RBP_SIDECAR_PATH", "").strip()
+if _sc:
+    extra_paths.append(_sc)
+extra_paths.append(
+    os.path.join(os.path.dirname(model_path_abs), model_name + ".rbp_rw_result.json")
+)
+
+process_open_document(
+    doc,
+    model_path_abs,
+    analytics_only,
+    log,
+    is_workshared_file,
+    doc_is_workshared,
+    "rbp",
+    model_path_obj,
+    extra_rw_result_paths=extra_paths,
+)
+
+log.debug("detach_repath_rbp complete")
+Output('Log File: "{}"'.format(log.log_file))

--- a/revit-worker/examples/ifc_export_rbp.py
+++ b/revit-worker/examples/ifc_export_rbp.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""RBP task script: IFC4 Reference View export.
+
+BatchRvt opens the model (--detach). Creates a 3D view if none exists.
+Launcher: Run-RBPIfcExport.ps1
+
+Environment:
+    RBP_EXPORT_DIR    output directory
+    RBP_IFC_FILENAME  stem without .ifc
+    RBP_JOB_ID        job id
+    RBP_SIDECAR_PATH  optional sidecar JSON path
+    RBP_PSET_FILE     optional user-defined property set file
+"""
+
+from __future__ import print_function
+
+import json
+import os
+import time
+import traceback
+
+import clr
+
+clr.AddReference("RevitAPI")
+from Autodesk.Revit.DB import (  # noqa: E402
+    FilteredElementCollector,
+    IFCExportOptions,
+    Transaction,
+    TransactionStatus,
+    View3D,
+    ViewFamily,
+    ViewFamilyType,
+)
+
+import revit_script_util
+from revit_script_util import Output
+
+doc = revit_script_util.GetScriptDocument()
+revitFilePath = revit_script_util.GetRevitFilePath()
+
+export_dir = os.environ.get("RBP_EXPORT_DIR", "")
+ifc_filename = os.environ.get("RBP_IFC_FILENAME", "")
+job_id = os.environ.get("RBP_JOB_ID", "unknown")
+pset_file = os.environ.get("RBP_PSET_FILE", "").strip() or None
+
+LOG_TAG = "[RBP-IFC]"
+
+
+def log(msg):
+    Output("{} {}".format(LOG_TAG, msg))
+
+
+def _safe_str(v):
+    if isinstance(v, dict):
+        return dict((_safe_str(k), _safe_str(val)) for k, val in v.items())
+    if isinstance(v, (list, tuple)):
+        return [_safe_str(i) for i in v]
+    if isinstance(v, bool) or v is None:
+        return v
+    if isinstance(v, (int, float)):
+        return v
+    try:
+        return str(v).encode("ascii", "replace").decode("ascii")
+    except Exception:
+        return repr(v)
+
+
+def write_rw_result(model_path, data):
+    safe_data = _safe_str(data)
+    sidecar_env = os.environ.get("RBP_SIDECAR_PATH", "")
+    model_basename = os.path.splitext(os.path.basename(model_path))[0]
+    model_dir = os.path.dirname(model_path)
+    sidecar_name = model_basename + ".rbp_rw_result.json"
+    candidates = [
+        sidecar_env if sidecar_env else None,
+        os.path.join(model_dir, sidecar_name),
+        os.path.join(export_dir, sidecar_name) if export_dir else None,
+        os.path.join(os.environ.get("TEMP", r"C:\Temp"), "rbp_ifc_export", sidecar_name),
+    ]
+    payload = json.dumps(safe_data, ensure_ascii=True)
+    print("RW_RESULT:" + payload)
+    for rw_file in candidates:
+        if not rw_file:
+            continue
+        try:
+            parent = os.path.dirname(rw_file)
+            if parent and not os.path.isdir(parent):
+                os.makedirs(parent)
+            with open(rw_file, "w") as fh:
+                fh.write(payload)
+            log("RW_RESULT written to {}".format(rw_file))
+            return
+        except Exception as e:
+            log("WARNING: Could not write sidecar {}: {}".format(rw_file, e))
+
+
+def find_or_create_3d_view(document):
+    collector = FilteredElementCollector(document).OfClass(View3D)
+    all_views = [v for v in collector if not v.IsTemplate]
+    log("Found {} non-template 3D views".format(len(all_views)))
+    if not all_views:
+        return create_3d_view(document), True
+    for v in all_views:
+        if v.Name == "{3D}":
+            log("Using default '{3D}' view")
+            return v, False
+    log("Using first 3D view: '{}'".format(all_views[0].Name))
+    return all_views[0], False
+
+
+def create_3d_view(document):
+    vft_3d = None
+    for vft in FilteredElementCollector(document).OfClass(ViewFamilyType).ToElements():
+        if vft.ViewFamily == ViewFamily.ThreeDimensional:
+            vft_3d = vft
+            break
+    if not vft_3d:
+        raise RuntimeError("No 3D ViewFamilyType found")
+    t = Transaction(document, "Create IFC export 3D view")
+    t.Start()
+    try:
+        new_view = View3D.CreateIsometric(document, vft_3d.Id)
+        new_view.Name = "IFC_Export_3D"
+        t.Commit()
+        log("Created 3D view IFC_Export_3D")
+        return new_view
+    except Exception:
+        if t.HasStarted() and not t.HasEnded():
+            t.RollBack()
+        raise
+
+
+def export_ifc(document, view, out_dir, filename):
+    options = IFCExportOptions()
+    options.FilterViewId = view.Id
+    try:
+        from Autodesk.Revit.DB import IFCVersion
+        options.FileVersion = IFCVersion.IFC4RV
+        log("IFC version: IFC4RV")
+    except Exception:
+        try:
+            from Autodesk.Revit.DB import IFCVersion
+            options.FileVersion = IFCVersion.IFC4
+            log("IFC version: IFC4")
+        except Exception as e:
+            log("WARNING: Could not set IFC version: {}".format(e))
+
+    options.SpaceBoundaryLevel = 0
+    options.ExportBaseQuantities = True
+    options.WallAndColumnSplitting = True
+    options.AddOption("ExportIFCCommonPropertySets", "true")
+    options.AddOption("StoreIFCGUID", "true")
+    options.AddOption("ExportVisibleElementsInView", "true")
+    options.AddOption("UseActiveViewGeometry", "true")
+    options.AddOption("TessellationLevelOfDetail", "0.25")
+
+    if pset_file:
+        options.AddOption("ExportUserDefinedPsets", "true")
+        options.AddOption("ExportUserDefinedPsetsFileName", pset_file)
+        log("Custom PSETs: {}".format(pset_file))
+    else:
+        options.AddOption("ExportUserDefinedPsets", "false")
+
+    if not os.path.isdir(out_dir):
+        try:
+            os.makedirs(out_dir)
+        except Exception as e:
+            log("WARNING: makedirs: {}".format(e))
+
+    log("Exporting: {}\\{}.ifc".format(out_dir, filename))
+    t0 = time.time()
+    try:
+        result = document.Export(out_dir, filename, options)
+    except Exception as e1:
+        if "transaction" not in str(e1).lower():
+            raise
+        log("Retrying export inside a Transaction")
+        txn = Transaction(document, "IFC Export")
+        txn.Start()
+        try:
+            result = document.Export(out_dir, filename, options)
+            if txn.GetStatus() == TransactionStatus.Started:
+                txn.Commit()
+        except Exception:
+            if txn.GetStatus() == TransactionStatus.Started:
+                txn.RollBack()
+            raise
+    log("doc.Export() returned {} in {:.1f}s".format(result, time.time() - t0))
+    return result
+
+
+rw = {
+    "ifc_exported": False,
+    "view_created": False,
+    "view_name": "",
+    "export_path": "",
+    "model_path": revitFilePath,
+    "job_id": job_id,
+    "pset_file": pset_file or "",
+}
+
+try:
+    if not export_dir:
+        raise RuntimeError("RBP_EXPORT_DIR not set")
+    raw_fname = ifc_filename if ifc_filename else os.path.splitext(
+        os.path.basename(revitFilePath or "model")
+    )[0]
+    fname = os.path.basename(raw_fname).replace("_detached", "")
+    view_3d, view_created = find_or_create_3d_view(doc)
+    rw["view_created"] = view_created
+    rw["view_name"] = view_3d.Name
+    rw["export_path"] = "{}\\{}.ifc".format(export_dir, fname)
+    export_result = export_ifc(doc, view_3d, export_dir, fname)
+    rw["ifc_exported"] = bool(export_result)
+    if export_result:
+        ifc_path = os.path.join(export_dir, fname + ".ifc")
+        try:
+            if os.path.isfile(ifc_path):
+                rw["ifc_size_mb"] = round(os.path.getsize(ifc_path) / 1048576.0, 1)
+        except Exception:
+            pass
+    else:
+        rw["error"] = "doc.Export() returned False"
+except Exception as exc:
+    log(traceback.format_exc())
+    rw["error"] = str(exc)
+finally:
+    write_rw_result(revitFilePath, rw)
+    log("=== RBP IFC export complete ===")

--- a/revit-worker/examples/model_audit.py
+++ b/revit-worker/examples/model_audit.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""Collect a compact model audit while a Revit document is open (RBP IronPython 2.7).
+
+Used by detach_repath.py. Returns a dict merged into RW_RESULT.
+"""
+
+from __future__ import print_function
+
+import os
+
+import clr
+
+clr.AddReference("RevitAPI")
+from Autodesk.Revit.DB import (  # noqa: E402
+    BasicFileInfo,
+    CategoryType,
+    FilteredElementCollector,
+    Level,
+    RevitLinkType,
+    View,
+    ViewSheet,
+)
+
+
+def _safe_str(x):
+    if x is None:
+        return ""
+    try:
+        return str(x).encode("ascii", "replace").decode("ascii")
+    except Exception:
+        try:
+            return unicode(x).encode("ascii", "replace").decode("ascii")  # noqa: F821
+        except Exception:
+            return ""
+
+
+def collect_analytics(doc, model_path_abs):
+    """Return a JSON-serializable audit dict for RW_RESULT."""
+    out = {
+        "warnings_total": 0,
+        "warnings_by_description": {},
+        "views_total": 0,
+        "views_by_type": {},
+        "sheets_total": 0,
+        "linked_models": [],
+        "levels": [],
+        "file_size_mb": None,
+        "revit_format": None,
+        "workshared": None,
+    }
+
+    try:
+        if os.path.isfile(model_path_abs):
+            out["file_size_mb"] = round(
+                float(os.path.getsize(model_path_abs)) / (1024.0 * 1024.0), 3
+            )
+            fi = BasicFileInfo.Extract(model_path_abs)
+            out["revit_format"] = _safe_str(fi.Format)
+            out["workshared"] = bool(fi.IsWorkshared)
+    except Exception:
+        pass
+
+    try:
+        warns = doc.GetWarnings()
+        out["warnings_total"] = len(warns)
+        by_desc = {}
+        for w in warns:
+            try:
+                desc = _safe_str(w.GetDescriptionText())
+            except Exception:
+                desc = "unknown"
+            by_desc[desc] = by_desc.get(desc, 0) + 1
+        out["warnings_by_description"] = by_desc
+    except Exception:
+        pass
+
+    try:
+        all_views = list(
+            FilteredElementCollector(doc)
+            .OfClass(View)
+            .WhereElementIsNotElementType()
+            .ToElements()
+        )
+        views_by_type = {}
+        n = 0
+        for v in all_views:
+            if getattr(v, "IsTemplate", False):
+                continue
+            vt = _safe_str(v.ViewType)
+            views_by_type[vt] = views_by_type.get(vt, 0) + 1
+            n += 1
+        out["views_total"] = n
+        out["views_by_type"] = views_by_type
+    except Exception:
+        pass
+
+    try:
+        sheets = list(
+            FilteredElementCollector(doc)
+            .OfClass(ViewSheet)
+            .WhereElementIsNotElementType()
+            .ToElements()
+        )
+        out["sheets_total"] = len(sheets)
+    except Exception:
+        pass
+
+    try:
+        links = []
+        for lt in FilteredElementCollector(doc).OfClass(RevitLinkType).ToElements():
+            links.append({"name": _safe_str(lt.Name), "loaded": bool(lt.IsLoaded)})
+        out["linked_models"] = links
+    except Exception:
+        pass
+
+    try:
+        levels = []
+        for lv in FilteredElementCollector(doc).OfClass(Level).ToElements():
+            row = {"name": _safe_str(lv.Name)}
+            try:
+                row["elevation_ft"] = float(lv.Elevation)
+            except Exception:
+                pass
+            levels.append(row)
+        out["levels"] = levels
+    except Exception:
+        pass
+
+    try:
+        cats = 0
+        for cat in doc.Settings.Categories:
+            try:
+                if cat.CategoryType == CategoryType.Model:
+                    cats += 1
+            except Exception:
+                pass
+        out["model_categories"] = cats
+    except Exception:
+        pass
+
+    return out


### PR DESCRIPTION
## Summary
- Add generic RBP launchers for detach + audit, model audit only, and IFC4 Reference View export.
- Document `POST /revit/execute` payloads in `revit-worker/examples/README.md` (no site-specific paths).

## Test plan
- [ ] Copy `revit-worker/examples/` onto the Windows host next to `RevitWorkerApp.exe`
- [ ] Enqueue each `.ps1` with `command_type: powershell` and a real `.rvt`
- [ ] For IFC export, pass `arguments: ["-ExportDir", "..."]` and confirm an `.ifc` is written
- [ ] Confirm stdout includes `RW_RESULT:{...}`


Made with [Cursor](https://cursor.com)