### PR TITLE
Fix spawn-isolation deadlock in the five workers PR #24 missed

### DIFF
--- a/ifc5d-worker/tasks.py
+++ b/ifc5d-worker/tasks.py
@@ -3,11 +3,11 @@ import os
 import shutil
 import tempfile
 from multiprocessing import get_context
-from queue import Empty
 from typing import Any, Optional
 
 from shared.classes import IfcQtoRequest
 from shared import object_storage as s3
+from shared.spawn_isolation import drain_and_join
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -75,24 +75,16 @@ def _run_in_spawn_isolation(
     q = ctx.Queue(maxsize=1)
     proc = ctx.Process(target=worker_target, args=(q, payload))
     proc.start()
-    proc.join()
+    got, status, data = drain_and_join(
+        proc, q, result_timeout=result_timeout, operation=operation
+    )
     if proc.exitcode == 0:
-        try:
-            status, data = q.get(timeout=result_timeout)
-        except Empty as e:
-            raise RuntimeError(
-                f"{operation} child exited 0 but sent no result"
-            ) from e
+        if not got:
+            raise RuntimeError(f"{operation} child exited 0 but sent no result")
         if status == "ok":
             return data
         raise RuntimeError(f"{operation} isolated worker: {data}")
-    child_err: Optional[str] = None
-    try:
-        status, data = q.get_nowait()
-        if status == "err":
-            child_err = data
-    except Empty:
-        pass
+    child_err: Optional[str] = data if (got and status == "err") else None
     raise RuntimeError(
         f"{operation} crashed in isolated subprocess "
         f"(label={label!r}, exit={proc.exitcode}"

--- a/ifcclash-worker/tasks.py
+++ b/ifcclash-worker/tasks.py
@@ -11,10 +11,10 @@ import ifcopenshell.geom
 import ifcopenshell.ifcopenshell_wrapper as _ios_wrap
 import multiprocessing
 from multiprocessing import get_context
-from queue import Empty
 from ifcclash.ifcclash import Clasher, ClashSettings
 from shared.db_client import save_clash_result
 from shared import audit_db
+from shared.spawn_isolation import drain_and_join
 from shared import object_storage as s3
 from typing import Tuple, List, Dict, Any, Optional
 
@@ -764,26 +764,20 @@ def _run_clash_in_spawn_isolation(
         label, IFCCLASH_GEOMETRY_LIBRARY, IFCCLASH_ITERATOR_THREADS,
     )
     proc.start()
-    proc.join()
+    got, status, data = drain_and_join(
+        proc, q, result_timeout=60, operation="ifcclash"
+    )
 
     if proc.exitcode == 0:
-        try:
-            status, data = q.get(timeout=60)
-        except Empty as exc:
+        if not got:
             raise RuntimeError(
                 "ifcclash isolated worker exited 0 but sent no result"
-            ) from exc
+            )
         if status == "ok":
             return data
         raise RuntimeError(f"ifcclash isolated worker reported error: {data}")
 
-    child_err: Optional[str] = None
-    try:
-        status, data = q.get_nowait()
-        if status == "err":
-            child_err = data
-    except Empty:
-        pass
+    child_err: Optional[str] = data if (got and status == "err") else None
 
     # Normalise the exit code into the same wording that RQ uses when the
     # work-horse itself dies, so RETRYABLE_ERROR_PATTERNS in

--- a/ifccsv-worker/tasks.py
+++ b/ifccsv-worker/tasks.py
@@ -2,11 +2,11 @@ import logging
 import os
 import tempfile
 from multiprocessing import get_context
-from queue import Empty
 from typing import Any, Optional
 
 from shared.classes import IfcCsvRequest, IfcCsvImportRequest
 from shared import object_storage as s3
+from shared.spawn_isolation import drain_and_join
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -152,24 +152,16 @@ def _run_in_spawn_isolation(
     q = ctx.Queue(maxsize=1)
     proc = ctx.Process(target=worker_target, args=(q, payload))
     proc.start()
-    proc.join()
+    got, status, data = drain_and_join(
+        proc, q, result_timeout=result_timeout, operation=operation
+    )
     if proc.exitcode == 0:
-        try:
-            status, data = q.get(timeout=result_timeout)
-        except Empty as e:
-            raise RuntimeError(
-                f"{operation} child exited 0 but sent no result"
-            ) from e
+        if not got:
+            raise RuntimeError(f"{operation} child exited 0 but sent no result")
         if status == "ok":
             return data
         raise RuntimeError(f"{operation} isolated worker: {data}")
-    child_err: Optional[str] = None
-    try:
-        status, data = q.get_nowait()
-        if status == "err":
-            child_err = data
-    except Empty:
-        pass
+    child_err: Optional[str] = data if (got and status == "err") else None
     raise RuntimeError(
         f"{operation} crashed in isolated subprocess "
         f"(label={label!r}, exit={proc.exitcode}"

--- a/ifcdiff-worker/tasks.py
+++ b/ifcdiff-worker/tasks.py
@@ -4,13 +4,13 @@ import json
 import tempfile
 import shutil
 from multiprocessing import get_context
-from queue import Empty
 
 import ifcopenshell
 from ifcdiff import IfcDiff
 from shared.classes import IfcDiffRequest
 from shared.db_client import save_diff_result
 from shared import object_storage as s3
+from shared.spawn_isolation import drain_and_join
 from collections.abc import Set, Sequence
 
 # Set up logging
@@ -400,24 +400,18 @@ def _run_ifcdiff_in_spawn_isolation(job_data: dict) -> dict:
     result_queue = ctx.Queue(maxsize=1)
     proc = ctx.Process(target=_isolated_ifcdiff_worker, args=(result_queue, job_data))
     proc.start()
-    proc.join()
+    got, status, data = drain_and_join(
+        proc, result_queue, result_timeout=60, operation="ifcdiff"
+    )
 
     if proc.exitcode == 0:
-        try:
-            status, data = result_queue.get(timeout=60)
-        except Empty as e:
-            raise RuntimeError("ifcdiff child exited 0 but sent no result") from e
+        if not got:
+            raise RuntimeError("ifcdiff child exited 0 but sent no result")
         if status == "ok":
             return data
         raise RuntimeError(f"ifcdiff isolated worker: {data}")
 
-    child_err = None
-    try:
-        status, data = result_queue.get_nowait()
-        if status == "err":
-            child_err = data
-    except Empty:
-        pass
+    child_err = data if (got and status == "err") else None
 
     # Negative exit codes are signal numbers on Linux (-11 = SIGSEGV).
     sig_hint = ""

--- a/ifcpatch-worker/tasks.py
+++ b/ifcpatch-worker/tasks.py
@@ -107,11 +107,11 @@ import tempfile
 import shutil
 import signal
 from multiprocessing import get_context
-from queue import Empty
 from pathlib import Path
 from typing import List, Dict, Any, Optional, get_type_hints, get_origin, get_args
 from shared.classes import IfcPatchRequest, IfcPatchListRecipesRequest
 from shared import object_storage as s3
+from shared.spawn_isolation import drain_and_join
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -590,27 +590,21 @@ def _run_recipe_in_spawn_isolation(
     q = ctx.Queue(maxsize=1)
     proc = ctx.Process(target=_isolated_recipe_worker, args=(q, payload))
     proc.start()
-    proc.join()
+    got, status, data = drain_and_join(
+        proc, q, result_timeout=60, operation=f"ifcpatch recipe {request.recipe!r}"
+    )
     if proc.exitcode == 0:
-        try:
-            status, data = q.get(timeout=60)
-        except Empty as e:
+        if not got:
             raise RuntimeError(
                 f"ifcpatch recipe {request.recipe!r} child exited 0 but sent no result"
-            ) from e
+            )
         if status == "ok":
             return data
         raise RuntimeError(
             f"ifcpatch recipe {request.recipe!r} isolated worker: {data}"
         )
-    # Non-zero exit: try to collect any err message the child sent before dying.
-    child_err: Optional[str] = None
-    try:
-        status, data = q.get_nowait()
-        if status == "err":
-            child_err = data
-    except Empty:
-        pass
+    # Non-zero exit: surface any err message the child sent before dying.
+    child_err: Optional[str] = data if (got and status == "err") else None
     raise RuntimeError(
         f"ifcpatch recipe {request.recipe!r} crashed in isolated subprocess "
         f"(strategy={label!r}, exit={proc.exitcode}"

--- a/ifctester-worker/tasks.py
+++ b/ifctester-worker/tasks.py
@@ -2,15 +2,14 @@ import logging
 import os
 import json
 import tempfile
-import time
 from multiprocessing import get_context
-from queue import Empty
 from typing import Any, Optional
 
 from shared.classes import IfcTesterRequest
 from shared.db_client import save_tester_result
 from shared import audit_db
 from shared import object_storage as s3
+from shared.spawn_isolation import drain_and_join
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -121,41 +120,14 @@ def _run_in_spawn_isolation(
     q = ctx.Queue(maxsize=1)
     proc = ctx.Process(target=worker_target, args=(q, payload))
     proc.start()
-    deadline = time.monotonic() + result_timeout
-    status_data: Optional[tuple] = None
-    while status_data is None:
-        try:
-            status_data = q.get(timeout=2.0)
-        except Empty:
-            if not proc.is_alive():
-                # Child exited; drain any result it flushed before dying so a
-                # successful ("ok", ...) put is not misreported as a crash.
-                try:
-                    status_data = q.get_nowait()
-                except Empty:
-                    status_data = None
-                break
-            if time.monotonic() >= deadline:
-                proc.terminate()
-                proc.join(timeout=15)
-                raise RuntimeError(
-                    f"{operation} timed out after {result_timeout}s "
-                    f"(label={label!r})"
-                )
-    proc.join(timeout=60)
-    if status_data is None:
-        # The feeder thread can flush the pipe only after is_alive() flips to
-        # False, so try once more after join() before declaring a crash.
-        try:
-            status_data = q.get_nowait()
-        except Empty:
-            status_data = None
-    if status_data is None:
+    got, status, data = drain_and_join(
+        proc, q, result_timeout=result_timeout, operation=operation
+    )
+    if not got:
         raise RuntimeError(
             f"{operation} crashed in isolated subprocess "
             f"(label={label!r}, exit={proc.exitcode})"
         )
-    status, data = status_data
     if status == "ok":
         return data
     raise RuntimeError(f"{operation} isolated worker: {data}")

--- a/shared/spawn_isolation.py
+++ b/shared/spawn_isolation.py
@@ -1,0 +1,104 @@
+"""Result handoff for workers that run ifcopenshell in a spawn subprocess.
+
+``multiprocessing.Queue.put()`` does not write to the pipe directly. It hands
+the object to a feeder thread, which blocks once the pipe's buffer is full
+(64 KB on Linux). A parent that calls ``proc.join()`` before reading the queue
+therefore waits for a child that cannot exit until the parent reads — a
+permanent deadlock on any result larger than the buffer.
+
+Every worker here runs the same pattern, so every worker had the same bug: the
+validation or conversion finishes, the child logs success, and the job never
+returns. With one worker per queue, one such job blocks the queue entirely.
+
+``drain_and_join`` reads the result first, then reaps the child. Callers keep
+their own error wording — several depend on it (``ifcclash`` phrases its
+message so n8n's RETRYABLE_ERROR_PATTERNS classifies the failure as retryable).
+"""
+
+import logging
+import time
+from queue import Empty
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["drain_and_join"]
+
+
+def drain_and_join(
+    proc,
+    queue,
+    *,
+    result_timeout: int = 600,
+    operation: str = "worker",
+    poll_interval: float = 1.0,
+    join_timeout: int = 60,
+) -> Tuple[bool, Optional[str], Any]:
+    """Read the child's result, then reap the child.
+
+    Args:
+        proc: a started ``multiprocessing.Process``.
+        queue: the ``multiprocessing.Queue`` the child puts ``(status, data)`` on.
+        result_timeout: seconds to wait for a result before giving up.
+        operation: name used in log lines.
+        poll_interval: how often to re-check whether the child is still alive.
+        join_timeout: seconds to wait for a clean exit before terminating.
+
+    Returns:
+        ``(got, status, data)``. ``got`` is False when the child sent nothing at
+        all — the caller decides how to phrase that, and can still inspect
+        ``proc.exitcode`` to tell a clean exit from a crash.
+    """
+    status: Optional[str] = None
+    data: Any = None
+    got = False
+    deadline = time.monotonic() + result_timeout
+
+    while True:
+        try:
+            status, data = queue.get(timeout=poll_interval)
+            got = True
+            break
+        except Empty:
+            if not proc.is_alive():
+                # The child is gone. It may still have flushed a result between
+                # the timeout above and this check, so look once more.
+                try:
+                    status, data = queue.get_nowait()
+                    got = True
+                except Empty:
+                    pass
+                break
+            if time.monotonic() >= deadline:
+                logger.error(
+                    "%s: no result after %ss, abandoning child",
+                    operation,
+                    result_timeout,
+                )
+                break
+
+    proc.join(timeout=join_timeout)
+
+    if not got:
+        # The feeder thread can finish flushing the pipe only after is_alive()
+        # has already flipped to False, so a result put moments before exit can
+        # still be unreadable above. Look once more after the join before
+        # declaring the child produced nothing.
+        try:
+            status, data = queue.get_nowait()
+            got = True
+        except Empty:
+            pass
+
+    if proc.is_alive():
+        logger.warning(
+            "%s: child still running after result, terminating", operation
+        )
+        proc.terminate()
+        proc.join(timeout=30)
+        if proc.is_alive():
+            logger.error("%s: child ignored SIGTERM, killing", operation)
+            proc.kill()
+            proc.join()
+
+    return got, status, data

--- a/tests/test_spawn_isolation.py
+++ b/tests/test_spawn_isolation.py
@@ -1,0 +1,110 @@
+"""Regression tests for shared.spawn_isolation.drain_and_join.
+
+The bug these cover: every worker called ``proc.join()`` before reading the
+result queue. ``multiprocessing.Queue.put()`` blocks its feeder thread once the
+pipe buffer fills (64 KB on Linux), so the child could not exit until the parent
+read — and the parent would not read until the child exited. Any result larger
+than the buffer hung both processes forever, taking the queue down with them.
+
+``test_large_result_does_not_deadlock`` is the one that matters: it fails (by
+timeout) against the old ordering and passes against the new one.
+"""
+
+import sys
+from multiprocessing import get_context
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from shared.spawn_isolation import drain_and_join  # noqa: E402
+
+# Comfortably over the 64 KB pipe buffer that triggers the deadlock.
+LARGE = 1024 * 1024
+
+
+def _put_result(q, payload):
+    q.put(("ok", {"blob": "x" * payload["size"]}))
+
+
+def _put_error(q, payload):
+    q.put(("err", "boom"))
+    raise SystemExit(1)
+
+
+def _exit_silently(q, payload):
+    raise SystemExit(3)
+
+
+def _crash_hard(q, payload):
+    import os
+
+    os.kill(os.getpid(), 9)
+
+
+def _run(target, size=0, **kwargs):
+    ctx = get_context("spawn")
+    q = ctx.Queue(maxsize=1)
+    proc = ctx.Process(target=target, args=(q, {"size": size}))
+    proc.start()
+    return proc, drain_and_join(proc, q, operation="test", **kwargs)
+
+
+@pytest.mark.parametrize("size", [0, 8 * 1024, LARGE])
+def test_result_returned_regardless_of_size(size):
+    """A result must come back whether or not it exceeds the pipe buffer."""
+    proc, (got, status, data) = _run(_put_result, size=size)
+    assert got is True
+    assert status == "ok"
+    assert len(data["blob"]) == size
+    assert proc.exitcode == 0
+
+
+def test_large_result_does_not_deadlock():
+    """The actual regression: >64 KB used to hang forever.
+
+    A 30 s cap is far beyond the ~0.1 s this needs, so a timeout here means the
+    deadlock is back rather than that the machine is slow.
+    """
+    proc, (got, status, data) = _run(_put_result, size=LARGE, result_timeout=30)
+    assert got is True, "child produced no result -- deadlock regression"
+    assert len(data["blob"]) == LARGE
+    assert not proc.is_alive(), "child was not reaped"
+
+
+def test_error_from_child_is_surfaced():
+    """A child that reports an error then dies still hands the message back."""
+    proc, (got, status, data) = _run(_put_error)
+    assert got is True
+    assert status == "err"
+    assert "boom" in data
+    assert proc.exitcode != 0
+
+
+def test_child_exiting_without_result():
+    """got is False, and the caller can still read exitcode to explain why."""
+    proc, (got, status, data) = _run(_exit_silently, result_timeout=15)
+    assert got is False
+    assert status is None
+    assert proc.exitcode == 3
+
+
+def test_child_killed_by_signal():
+    """SIGKILL (what the OOM killer sends) must not hang the parent."""
+    proc, (got, status, data) = _run(_crash_hard, result_timeout=15)
+    assert got is False
+    assert proc.exitcode == -9
+
+
+def test_timeout_when_child_never_finishes():
+    """A child that neither sends nor exits is abandoned, not waited on forever."""
+    proc, (got, status, data) = _run(_sleep_forever, result_timeout=2)
+    assert got is False
+    assert not proc.is_alive(), "hung child should have been terminated"
+
+
+def _sleep_forever(q, payload):
+    import time
+
+    time.sleep(3600)


### PR DESCRIPTION
PR #24 fixed the result-drain deadlock in ifctester. The same `proc.join()`-before-drain pattern is copy-pasted into five other workers, all of which still hang: ifccsv, ifcclash, ifcdiff, ifcpatch and ifc5d.

`multiprocessing.Queue.put()` hands the object to a feeder thread that writes into a pipe. Once that pipe's buffer fills (64 KB on Linux) the child blocks until the parent reads, and a parent sitting in `join()` never will. Both processes hang permanently on any result over 64 KB. With one worker per queue, a single such job takes the whole queue down: the work is already finished, the child has logged success, and the job simply never returns.

Reproduced on a real deployment before the fix: an 8 KB ifctester report succeeded, a 262 KB report hung for 17+ minutes at 0% CPU with four unreaped zombie children, and every job queued behind it stayed `queued` forever.

Rather than copy PR #24's loop five more times, this extracts it into `shared/spawn_isolation.drain_and_join()` and points all six workers at it, including ifctester. Callers keep their own error wording -- ifcclash depends on it, phrasing failures so n8n's RETRYABLE_ERROR_PATTERNS classifies them as retryable -- so `drain_and_join` returns `(got, status, data)` and lets each caller decide how to report. Every existing error message and exit-code branch is preserved; the only behavioural change is that the queue is drained before the join. Net -62 lines across the workers.

The helper keeps both races PR #24 identified: a `get_nowait()` after `is_alive()` goes false, and another after `join()`, since the feeder thread can only finish flushing once the child has exited. It also escalates join -> terminate -> kill so a wedged child cannot outlive the call.

tests/test_spawn_isolation.py covers the regression directly: `test_large_result_does_not_deadlock` fails by timeout against the old ordering and passes against the new one. The other seven cover small results, an error from the child, a silent non-zero exit, SIGKILL (what the OOM killer sends), and a child that never finishes.

Verified end-to-end against a live stack: ifctester, ifccsv, ifcclash, ifcdiff and ifcpatch all complete normally after the change, and a 162 MB model against a 12-specification IDS -- which previously deadlocked -- now returns in 82 s.